### PR TITLE
Allow for a Sirius initialization callback. (Issue #17)

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/Sirius1Dot2Extensions.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/Sirius1Dot2Extensions.scala
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2014 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.comcast.xfinity.sirius.api.impl
+
+import com.comcast.xfinity.sirius.api.Sirius
+
+/**
+ * These are additional methods supported by an expanded Sirius interface.
+ */
+trait Sirius1Dot2Extensions {
+  /**
+   * Register a callback to be invoked once the Sirius subsystem has been
+   * initialized (i.e. log replay has completed). This may be called
+   * multiple times to install multiple init hook callbacks; each will be
+   * called once upon initialization. If Sirius has already been
+   * initialized, the callback will be invoked right away.
+   *
+   * @param initHook callback to run
+   */
+  def onInitialized(initHook: Runnable): Unit
+}
+
+trait Sirius1Dot2 extends Sirius with Sirius1Dot2Extensions

--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/SiriusSupervisorTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/SiriusSupervisorTest.scala
@@ -116,6 +116,32 @@ class SiriusSupervisorTest extends NiceTest with BeforeAndAfterAll with TimedTes
       waitForTrue(stateAgent().supervisorInitialized, 5000, 250)
     }
 
+    it("should reply to a registered initHook once initialized") {
+      val probe = TestProbe()
+      probe.send(supervisor, SiriusSupervisor.RegisterInitHook)
+      initializeSupervisor(supervisor)
+      probe.expectMsg(SiriusSupervisor.Initialized)
+    }
+
+    it("should reply to all registered initHooks once initialized") {
+      val probe1 = TestProbe()
+      val probe2 = TestProbe()
+      probe1.send(supervisor, SiriusSupervisor.RegisterInitHook)
+      probe2.send(supervisor, SiriusSupervisor.RegisterInitHook)
+      initializeSupervisor(supervisor)
+      probe1.expectMsg(SiriusSupervisor.Initialized)
+      probe2.expectMsg(SiriusSupervisor.Initialized)
+    }
+
+    it("should reply immediately to an initHook registration once already initialized") {
+      val probe = TestProbe()
+      val stateAgent = supervisor.underlyingActor.siriusStateAgent
+      initializeSupervisor(supervisor)
+      waitForTrue(stateAgent().supervisorInitialized, 5000, 250)
+      probe.send(supervisor, SiriusSupervisor.RegisterInitHook)
+      probe.expectMsg(SiriusSupervisor.Initialized)
+    }
+
     it("should forward MembershipMessages to the membershipActor") {
       initializeSupervisor(supervisor)
       initializeOrdering(supervisor, Some(paxosProbe.ref))


### PR DESCRIPTION
Adds some messages to the SiriusSupervisor so that you can
send it a message to register interest in an initialization
event and get a message back once that has occurred. Added
an onInitialized() method to SiriusImpl to hook that up to
a callback. This addresses issue #17.

Also defined a new trait/interface `Sirius1Dot2` that
extends `Sirius`. This seems like a good way to track
the additional methods without losing backwards
compatibility with version 1.1.4. In theory, this new
interface would be modifiable up until the next release
(which should be 1.2.0 in this case).

Discussion points:
- onInitialized takes a java.lang.Runnable as a callback to
  facilitate calling it from Java. Kinda kludgy, since from
  Scala it would just want a lazy `=> Unit`.
- Does the approach with the additional interface seem ok?
