### PR TITLE
SiriusResult should wrap Throwable (issue #8)

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/SiriusResult.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/SiriusResult.scala
@@ -41,12 +41,12 @@ object SiriusResult {
    *
    * @return SiriusResult 
    */  
-  def error(rte: RuntimeException): SiriusResult = SiriusResult(Left(rte))
+  def error(rte: RuntimeException): SiriusResult = exception(rte)
 
   /**
-   * Factory method for creating a SiriusResult with an error.
+   * Factory method for creating a SiriusResult with an exception.
    *
-   * @param rte the RuntimeException to wrap
+   * @param t the Throwable to wrap
    *
    * @return SiriusResult 
    */  
@@ -90,4 +90,17 @@ case class SiriusResult(private val value: Either[Throwable, Option[Object]]) {
    * @return true if this instance wraps an exception
    */
   def isError: Boolean = value.isLeft
+
+  /**
+   * Retrieves the exception associated with this result.  If an exception
+   * has not been set an IllegalStateException is thrown.
+   * 
+   * @return the Throwable wrapped by this instance if it exists
+   * @throws IllegalStateException if no such Throwable exists
+   */
+  def getException: Throwable = value match {
+    case Left(t) => t
+    case _ => throw new IllegalStateException("Result has no exception")
+  }
+
 }

--- a/src/test/scala/com/comcast/xfinity/sirius/api/SiriusResultTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/SiriusResultTest.scala
@@ -87,6 +87,19 @@ class SiriusResultTest extends NiceTest {
           SiriusResult.error(new RuntimeException()).isError
         }
       }
+
+      it("should throw an IllegalStateException when it has no exception") {
+        intercept[IllegalStateException] {
+          SiriusResult.none().getException
+        }
+      }
+      
+      it("should return the exception when it has been set") {
+        assertResult(true) {
+          val t = new Throwable()
+          SiriusResult.exception(t).getException == t
+        }
+      }      
     }
   }
 }


### PR DESCRIPTION
There's no particular reason why SiriusResult can only wrap RuntimeException as an error, so generalise it to Throwable (analogous to the Scala Try class).

See https://github.com/Comcast/sirius/issues/8
