### PR TITLE
Set up an area for the enhanced 1.2.x interface.

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/Sirius.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/Sirius.scala
@@ -17,6 +17,8 @@ package com.comcast.xfinity.sirius.api
 
 import java.util.concurrent.Future
 
+@deprecated(message = "Please upgrade to using com.comcast.xfinity.sirius.api.api1Dot2.Sirius1Dot2 instead",
+  since = "1.2.0")
 trait Sirius {
   
   /**

--- a/src/main/scala/com/comcast/xfinity/sirius/api/api1Dot2/Sirius1Dot2.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/api1Dot2/Sirius1Dot2.scala
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2014 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.comcast.xfinity.sirius.api.api1Dot2
+
+import com.comcast.xfinity.sirius.api.{Sirius => Sirius1Dot1}
+
+/**
+ * Methods added to the abstract Sirius interface in the 1.2.x series release(s).
+ */
+trait Sirius1Dot2Extensions {
+
+  /**
+   * Terminate this instance, including shutting down all internal running Actors.
+   */
+  def shutdown(): Unit
+}
+
+/**
+ * Enhanced abstract Sirius interface made available in the 1.2.x series release(s).
+ */
+trait Sirius1Dot2 extends Sirius1Dot1 with Sirius1Dot2Extensions
+


### PR DESCRIPTION
- This creates a new package specifically for the 1.2 interface.
  The idea is that we could collect interface enhancements in
  similar packages as we go on.
- Deprecated the old `Sirius` (1.1.x) interface.

Discussion questions:
- What else should go into this package? Ideally this should be everything that a client would need to interact with.
- What do you think of creating a versioned package like this?
- Is the package in the right place?
- Does the package need a `package.html` (or whatever the ScalaDoc equivalent is)?
- I suspect we will find we want classes like `Sirius1Dot2Impl` that are essentially interface adapters to a single `SiriusImpl`. One complicating factor is that `SiriusImpl` is a "public" class in 1.1.x because the `SiriusFactory` returns it. So probably the single, private core class needs a different name (`SiriusFacade`?).

References:
- PRs #21 and #23 are related.
- Issues #8, #11, #17, #19, and #25.
