### PR TITLE
fix event-handler deprecation

### DIFF
--- a/src/main/bin/akka-overrides.conf
+++ b/src/main/bin/akka-overrides.conf
@@ -1,4 +1,4 @@
 akka {
-    event-handlers = ["akka.event.Logging$DefaultLogger"]
+    loggers = ["akka.event.Logging$DefaultLogger"]
     loglevel = DEBUG
 }

--- a/src/main/resources/sirius-akka-base.conf
+++ b/src/main/resources/sirius-akka-base.conf
@@ -1,5 +1,5 @@
 akka {
-  event-handlers = ["com.comcast.xfinity.sirius.util.Slf4jEventHandlerWithRemotingSilencer"]
+  loggers = ["com.comcast.xfinity.sirius.util.Slf4jEventHandlerWithRemotingSilencer"]
   loglevel = DEBUG
   log-config-on-startup = on
 

--- a/src/test/resources/sirius-akka-base.conf
+++ b/src/test/resources/sirius-akka-base.conf
@@ -1,5 +1,5 @@
 akka {
-  //event-handlers = ["com.comcast.xfinity.sirius.util.Slf4jEventHandlerWithRemotingSilencer"]
+  //loggers = ["com.comcast.xfinity.sirius.util.Slf4jEventHandlerWithRemotingSilencer"]
   loglevel = "ERROR"
   stdout-loglevel = "ERROR"
   log-config-on-startup = off

--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/SiriusImplTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/SiriusImplTest.scala
@@ -66,7 +66,7 @@ class SiriusImplTest extends NiceTest with TimedTest {
 
   before {
     actorSystem = ActorSystem("testsystem", ConfigFactory.parseString("""
-            akka.event-handlers = ["akka.testkit.TestEventListener"]
+            akka.loggers = ["akka.testkit.TestEventListener"]
     """))
 
     membership = mock[Map[String, Option[ActorRef]]]


### PR DESCRIPTION
akka.event-handler has been deprecated and akka.loggers should be
used instead.  All references have been fixed.  This fixes issue #30
