### PR TITLE
remove scala 2.10.3 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: scala
 scala:
    - 2.10.2
-   - 2.10.3-RC3


### PR DESCRIPTION
This was experimental and has caused troubles with our build. After
this change we should consider future travis failures as potential
bugs.
