### PR TITLE
cleanup scaladoc

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/SiriusImpl.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/SiriusImpl.scala
@@ -89,7 +89,7 @@ class SiriusImpl(config: SiriusConfiguration, supProps: Props)(implicit val acto
   }
 
   /**
-   * ${@inheritDoc}
+   * @inheritdoc
    */
   def enqueueGet(key: String): Future[SiriusResult] = {
     val akkaFuture = (supervisor ? Get(key)).asInstanceOf[AkkaFuture[SiriusResult]]
@@ -97,7 +97,7 @@ class SiriusImpl(config: SiriusConfiguration, supProps: Props)(implicit val acto
   }
 
   /**
-   * ${@inheritDoc}
+   * @inheritdoc
    */
   def enqueuePut(key: String, body: Array[Byte]): Future[SiriusResult] = {
     //XXX: this will always return a Sirius.None as soon as Ordering is complete
@@ -106,7 +106,7 @@ class SiriusImpl(config: SiriusConfiguration, supProps: Props)(implicit val acto
   }
 
   /**
-   * ${@inheritDoc}
+   * @inheritdoc
    */
   def enqueueDelete(key: String): Future[SiriusResult] = {
     val akkaFuture = (supervisor ? Delete(key)).asInstanceOf[AkkaFuture[SiriusResult]]

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/paxos/PaxosSupervisor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/paxos/PaxosSupervisor.scala
@@ -28,7 +28,7 @@ object PaxosSupervisor {
   /**
    * Factory for creating children actors of PaxosSup.
    *
-   * @param membership an [[ akka.agent.Agent]] tracking the membership of the cluster
+   * @param membership an [[akka.agent.Agent]] tracking the membership of the cluster
    * @param startingSeq the sequence number at which this node will begin issuing/acknowledging
    * @param performFun function specified by
    *          [[com.comcast.xfinity.sirius.api.impl.paxos.Replica.PerformFun]], applied to

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberPair.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberPair.scala
@@ -84,9 +84,6 @@ object UberPair {
  */
 class UberPair(dataFile: UberDataFile, index: SeqIndex) {
 
-  /**
-   * @inheritdoc
-   */
   def writeEntry(event: OrderedEvent) {
     if (isClosed) {
       throw new IllegalStateException("Attempting to write to closed UberStoreFilePair")
@@ -98,23 +95,14 @@ class UberPair(dataFile: UberDataFile, index: SeqIndex) {
     index.put(event.sequence, offset)
   }
 
-  /**
-   * @inheritdoc
-   */
   def getNextSeq = index.getMaxSeq match {
     case None => 1L
     case Some(seq) => seq + 1
   }
 
-  /**
-   * @inheritdoc
-   */
   def foldLeft[T](acc0: T)(foldFun: (T, OrderedEvent) => T): T =
     foldLeftRange(0, Long.MaxValue)(acc0)(foldFun)
 
-  /**
-   * @inheritdoc
-   */
   def foldLeftRange[T](startSeq: Long, endSeq: Long)(acc0: T)(foldFun: (T, OrderedEvent) => T): T = {
     val (startOffset, endOffset) = index.getOffsetRange(startSeq, endSeq)
     dataFile.foldLeftRange(startOffset, endOffset)(acc0)(

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/seqindex/SeqIndexBinaryFileOps.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/seqindex/SeqIndexBinaryFileOps.scala
@@ -101,7 +101,7 @@ class SeqIndexBinaryFileOps private[seqindex](checksummer: Checksummer,
    *
    * Not thread safe with respect to indexFileHandle
    *
-   * @indexFileHandle RandomAccessFile for the index file, it's offset
+   * @param indexFileHandle RandomAccessFile for the index file, it's offset
    *                    will be advanced 24 bytes (entry length)
    */
   def readEntry(indexFileHandle: RandomAccessFile): (Long, Long) = {

--- a/src/main/scala/com/comcast/xfinity/sirius/util/AkkaExternalAddressResolver.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/util/AkkaExternalAddressResolver.scala
@@ -27,8 +27,10 @@ object AkkaExternalAddressResolver {
  * Class for figuring out a local actor refs remote address.  This is weird, and I got
  * the gist of it from the following guys:
  *
- *  https://groups.google.com/forum/?fromgroups=#!searchin/akka-user/full$20address/akka-user/POngjU9UpK8/wE74aYiWdWIJ
- *  http://doc.akka.io/docs/akka/snapshot/scala/serialization.html
+ *  <ul>
+ *    <li>[[https://groups.google.com/forum/?fromgroups=#!searchin/akka-user/full\$20address/akka-user/POngjU9UpK8/wE74aYiWdWIJ]]</li>
+ *    <li>[[http://doc.akka.io/docs/akka/snapshot/scala/serialization.html]]</li>
+ *  </ul>
  *
  * Don't use directly, akka does some voodoo to make the ExtendedActorSystem available.
  *

--- a/src/main/scala/com/comcast/xfinity/sirius/util/RichJTreeMap.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/util/RichJTreeMap.scala
@@ -25,7 +25,7 @@ object RichJTreeMap {
    * Create a RichJTreeMap and populate with provided
    * elements
    *
-   * @kvs varargs of key/value pairs, same as you would
+   * @param kvs varargs of key/value pairs, same as you would
    *        construct standard Scala Maps
    */
   def apply[K, V](kvs: (K, V)*): RichJTreeMap[K, V] = {

--- a/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/CachedSiriusLog.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/CachedSiriusLog.scala
@@ -46,7 +46,7 @@ class CachedSiriusLog(log: SiriusLog, maxCacheSize: Int) extends SiriusLog {
   private[writeaheadlog] var lastSeq = -1L
 
   /**
-   * ${inheritDoc}
+   * @inheritdoc
    *
    * Writes both to disk and to the in-mem write cache.  Trims cache if necessary,
    * depending on MAX_CACHE_SIZE.
@@ -78,7 +78,7 @@ class CachedSiriusLog(log: SiriusLog, maxCacheSize: Int) extends SiriusLog {
   }
 
   /**
-   * ${inheritDoc}
+   * @inheritdoc
    *
    * For bounded LogRange requests, will check write cache first, replying with
    * entries from memory if possible.  This should avoid seeking the range on disk

--- a/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/SiriusLog.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/SiriusLog.scala
@@ -52,6 +52,9 @@ trait SiriusLog {
    */
   def foldLeftRange[T](startSeq: Long, endSeq: Long)(acc0: T)(foldFun: (T, OrderedEvent) => T): T
 
+  /**
+   * retrieves the next sequence number to be written
+   */
   def getNextSeq: Long
 
   def compact()


### PR DESCRIPTION
fixed various issues in the scaladoc to remove all but two of the
scaladoc warnings. The last two unresolved warnings relate to
linking to external scaladoc / javadoc. I could not figure out how to
get scaladoc to link to external documents without using absolute
urls. Will make this a separate issue in case we want to pursue this.

see related issue #41
