### PR TITLE
Delete all testing tmp dirs, uncollide two tests

### DIFF
--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/UberStoreITest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/UberStoreITest.scala
@@ -20,6 +20,7 @@ import java.io.File
 import org.scalatest.BeforeAndAfterAll
 import com.comcast.xfinity.sirius.NiceTest
 import com.comcast.xfinity.sirius.api.impl.{Delete, OrderedEvent}
+import scalax.file.Path
 
 class UberStoreITest extends NiceTest with BeforeAndAfterAll {
 
@@ -34,7 +35,7 @@ class UberStoreITest extends NiceTest with BeforeAndAfterAll {
   }
 
   override def afterAll {
-    tempDir.delete()
+    Path(tempDir).deleteRecursively(force = true)
   }
 
   // XXX: not these sub tasks are not parallelizable
@@ -51,7 +52,7 @@ class UberStoreITest extends NiceTest with BeforeAndAfterAll {
 
     val events1Through100 = generateEvents(1, 100)
     it ("must be able to accept and retain a bunch of Delete events") {
-      events1Through100.foreach(uberStore.writeEntry(_))
+      events1Through100.foreach(uberStore.writeEntry)
       assert(events1Through100 === getAllEvents(uberStore))
     }
 
@@ -75,7 +76,7 @@ class UberStoreITest extends NiceTest with BeforeAndAfterAll {
       assert(101L === uberStore.getNextSeq)
       assert(events1Through100 === getAllEvents(uberStore))
 
-      events101Through200.foreach(uberStore.writeEntry(_))
+      events101Through200.foreach(uberStore.writeEntry)
       assert(201L === uberStore.getNextSeq)
       assert(events1Through100 ++ events101Through200 === getAllEvents(uberStore))
     }

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentTest.scala
@@ -25,6 +25,7 @@ import java.io.File
 import org.scalatest.BeforeAndAfterAll
 import scala.collection.immutable.StringOps
 import com.comcast.xfinity.sirius.api.impl.{Put, Delete, OrderedEvent}
+import scalax.file.Path
 
 object SegmentTest {
 
@@ -54,7 +55,7 @@ class SegmentTest extends NiceTest with BeforeAndAfterAll {
   }
 
   override def afterAll() {
-    tempDir.delete()
+    Path(tempDir).deleteRecursively(force = true)
   }
   describe("writeEntry") {
     it ("must persist the event to the dataFile, and offset to the index") {

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
@@ -27,7 +27,7 @@ import com.comcast.xfinity.sirius.api.SiriusConfiguration
 class SegmentedUberStoreTest extends NiceTest {
 
   def createTempDir = {
-    val tempDirName = "%s/uberstore-itest-%s".format(
+    val tempDirName = "%s/segmented-uberstore-test-%s".format(
       System.getProperty("java.io.tmpdir"),
       System.currentTimeMillis()
     )
@@ -84,7 +84,8 @@ class SegmentedUberStoreTest extends NiceTest {
   }
 
   after {
-    Path.fromString(dir.getAbsolutePath).deleteRecursively(force = true)
+    println(dir.getAbsolutePath)
+    Path(dir).deleteRecursively(force = true)
     Thread.sleep(5)
   }
 
@@ -380,7 +381,6 @@ class SegmentedUberStoreTest extends NiceTest {
 
   describe("repair") {
     it("should properly handle the existence of both base and compacted") {
-      val dir = createTempDir
       createPopulatedSegment(dir, "1", List(1))
       createPopulatedSegment(dir, "1" + SegmentedCompactor.COMPACTING_SUFFIX, List(2))
 
@@ -389,7 +389,6 @@ class SegmentedUberStoreTest extends NiceTest {
       assert(dir.listFiles().count(_.isDirectory) == 1)
     }
     it("should properly handle the existence of both temp and compacted") {
-      val dir = createTempDir
       createPopulatedSegment(dir, "1.temp", List(1))
       createPopulatedSegment(dir, "1" + SegmentedCompactor.COMPACTING_SUFFIX, List(2))
 
@@ -398,7 +397,6 @@ class SegmentedUberStoreTest extends NiceTest {
       assert(dir.listFiles().count(_.isDirectory) == 1)
     }
     it("should properly handle the existence of both base and temp") {
-      val dir = createTempDir
       createPopulatedSegment(dir, "1", List(1))
       createPopulatedSegment(dir, "1" + SegmentedCompactor.TEMP_SUFFIX, List(2))
 
@@ -407,7 +405,6 @@ class SegmentedUberStoreTest extends NiceTest {
       assert(dir.listFiles().count(_.isDirectory) == 1)
     }
     it("should do nothing if the SegmentedUberStore is proper") {
-      val dir = createTempDir
       createPopulatedSegment(dir, "1", List(1))
       createPopulatedSegment(dir, "2", List(2))
 
@@ -416,7 +413,6 @@ class SegmentedUberStoreTest extends NiceTest {
       assert(dir.listFiles().count(_.isDirectory) == 2)
     }
     it("should do the expected things when all of the error cases appear at once") {
-      val dir = createTempDir
       createPopulatedSegment(dir, "1", List(1))
       createPopulatedSegment(dir, "2", List(2))
       createPopulatedSegment(dir, "2" + SegmentedCompactor.COMPACTING_SUFFIX, List(20))
@@ -434,18 +430,15 @@ class SegmentedUberStoreTest extends NiceTest {
 
   describe("size"){
     it ("should report size correctly with 0 segments"){
-      val dir = createTempDir
       assert(0L === SegmentedUberStore(dir.getAbsolutePath).size)
     }
 
     it ("should report size correctly with 1 segments"){
-      val dir = createTempDir
       createPopulatedSegment(dir, "1", List(1))
       assert(65L === SegmentedUberStore(dir.getAbsolutePath).size)
     }
 
     it ("should report size correctly with multiple segments"){
-      val dir = createTempDir
       createPopulatedSegment(dir, "1", List(1))
       createPopulatedSegment(dir, "2", List(2))
       createPopulatedSegment(dir, "3", List(3))

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/seqindex/DiskOnlySeqIndexTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/seqindex/DiskOnlySeqIndexTest.scala
@@ -19,6 +19,7 @@ package com.comcast.xfinity.sirius.uberstore.seqindex
 import com.comcast.xfinity.sirius.NiceTest
 import java.io.File
 import org.scalatest.BeforeAndAfterAll
+import scalax.file.Path
 
 // here's the deal, this is insane to try to test with mockery,
 //  so do the real deal
@@ -35,7 +36,7 @@ class DiskOnlySeqIndexTest extends NiceTest with BeforeAndAfterAll {
   }
 
   override def afterAll {
-    tempDir.delete()
+    Path(tempDir).deleteRecursively(force = true)
   }
 
   describe("Index size"){


### PR DESCRIPTION
Two tests were colliding on temp directories in rare cases (tests run in
parallel at the same ms). This fixes that. This also makes sure that all
the temp directories created by tests are actually deleted --
file.delete() does not do the trick.
