### PR TITLE
cleanup unit tests

### DIFF
--- a/src/test/scala/com/comcast/xfinity/sirius/itest/FullSystemITest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/itest/FullSystemITest.scala
@@ -376,7 +376,7 @@ class FullSystemITest extends NiceTest with TimedTest {
     assert(waitForTrue(verifyWalSize(log3, numCommands), 30000, 500),
       "Wal 3 did not contain expected number of events (%s out of %s)".format(getWalSize(log3), numCommands))
 
-    assert(waitForTrue(verifyWalsAreEquivalent(List(log1, log2, log3)), 500, 100),
+    assert(waitForTrue(verifyWalsAreEquivalent(List(log1, log2, log3)), 10000, 100),
       "Wals were not equivalent")
   }
 }

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
@@ -84,7 +84,6 @@ class SegmentedUberStoreTest extends NiceTest {
   }
 
   after {
-    println(dir.getAbsolutePath)
     Path(dir).deleteRecursively(force = true)
     Thread.sleep(5)
   }


### PR DESCRIPTION
- increased a timeout in FullSystemITest when comparing logs.
  Sometimes travis fails here, suspect it is because there is not
  enough time for the test to succeed
- removed an unnecessary `println` in SegmentedUberStoreTest
