### PR TITLE
Reduce file I/O ops when reading uberstore files

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/UberStoreFileOps.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/UberStoreFileOps.scala
@@ -45,7 +45,7 @@ trait UberStoreFileOps {
    * @param readHandle the RandomAccessFile to read from, at the
    *          current offset
    *
-   * @return Some(bytes) or None if EOF encountered
+   * @return Some(bytes, nextOffset) or None if EOF encountered.
    */
-  def readNext(readHandle: RandomAccessFile): Option[Array[Byte]]
+  def readNext(readHandle: RandomAccessFile, offset: Long, length: Long): Option[(Array[Byte], Long)]
 }


### PR DESCRIPTION
This change updates UberStoreFileOps interface to pass in the current
offset and length when reading an entry from an UberStore file rather
than calling the RandomAccessFile getFilePointer() and length() methods.

It also amends the returned value to also return the nextOffset along with
the entry.

Profiling in JProfiler showed that these operations were expensive.

The repeated calls are unnecessary because the offset can be accounted
for with simple math, and the length of the file should only grow while
while it is open for reading.

Uberstore replay time with this change is reduced 14% (1029s -> 886s)
using a production Uberstore file on production-like hardware.
