### PR TITLE
Fix tty restoration logic in sirius-standalone

### DIFF
--- a/src/main/bin/sirius-interactive.sh
+++ b/src/main/bin/sirius-interactive.sh
@@ -23,10 +23,10 @@ exit_code=1
 saved_stty=""
 
 function onExit {
-    if [ "$saved_tty" == "" ]; then
+    if [ ! -z "$saved_stty" ]; then
         stty $saved_stty
-        exit $exit_code
     fi
+    exit $exit_code
 }
 
 trap onExit EXIT


### PR DESCRIPTION
While this currently works the logic is off- we're checking to see
if saved_tty is empty, however saved_tty was never set. What we
meant to do was check if saved_stty is non-empty.

Additionally move the exit portion out of the if as the if could be
not followed.
