### PR TITLE
Disable parallel testing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,5 +42,7 @@ scalacOptions in (Compile,doc) ++= Seq("-doc-footer",
 
 scalacOptions in (Compile, doc) ++= Seq("-doc-root-content", "src/main/resources/overview.txt")
 
+parallelExecution := false
+
 // allows us to pull deps from pom file
 externalPom()


### PR DESCRIPTION
We've seen some spurious failures from FullSystemITest on Travis. This
kind of thing has generally been tied to really underpowered hardware
running what ends up being a fairly distributed application. In any
case, we think making sure that no other tests are running at the same
time might be helpful.
