### PR TITLE
Increase FullSystemITest membership timeout

### DIFF
--- a/src/test/scala/com/comcast/xfinity/sirius/itest/FullSystemITest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/itest/FullSystemITest.scala
@@ -172,7 +172,7 @@ class FullSystemITest extends NiceTest with TimedTest {
     assert(waitForTrue({
       sirii.foreach(_.supervisor ! CheckClusterConfig)
       sirii.forall(_.getMembership.get.values.flatten.size == membersExpected)
-    }, 5000, 1500),
+    }, 10000, 1500),
       "Membership did not reach expected size: expected %s, got %s"
         .format(membersExpected, sirii.map(_.getMembership.get.values.flatten.size)))
     sirii.foreach(_.supervisor ! CheckPaxosMembership)


### PR DESCRIPTION
This has failed a couple of times, and we have a little evidence that
it's just barely missing. I don't like to just increase timeouts when we
see failures, but I'm not finding a better way to do it right now. Let's
increase the timeout for now, and if we still see failures, maybe take
another approach.
