### PR TITLE
Make akka max-frame-size configurable

### DIFF
--- a/src/main/resources/sirius-akka-base.conf
+++ b/src/main/resources/sirius-akka-base.conf
@@ -23,9 +23,6 @@ common-netty-settings {
   hostname = ""
   port = 2552
 
-  # band-aid while our messages are too big :)
-  message-frame-size = 100 MiB
-
   # this is probably too liberal
   connection-timeout = 2s
 

--- a/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
@@ -270,6 +270,11 @@ object SiriusConfiguration {
    * Congestion Avoidance. Default is 500.
    */
   final val CATCHUP_DEFAULT_SSTHRESH = "sirius.catchup.default-ssthresh"
+
+  /*
+   * Maximum akka message size in KB. Default is 1024.
+   */
+  final val MAX_AKKA_MESSAGE_SIZE_KB = "sirius.akka.maximum-frame-size-kb"
 }
 
 /**

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/SiriusFactory.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/SiriusFactory.scala
@@ -26,8 +26,7 @@ import com.comcast.xfinity.sirius.api.SiriusConfiguration
 import com.comcast.xfinity.sirius.info.SiriusInfo
 import com.comcast.xfinity.sirius.writeaheadlog.CachedSiriusLog
 import com.comcast.xfinity.sirius.writeaheadlog.SiriusLog
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
@@ -158,6 +157,12 @@ object SiriusFactory {
     configMap.put(s"$transportPrefix.hostname",
       siriusConfig.getProp(SiriusConfiguration.HOST, InetAddress.getLocalHost.getHostName))
     configMap.put(s"$transportPrefix.port", siriusConfig.getProp(SiriusConfiguration.PORT, 2552))
+
+    val maxMessageSize = siriusConfig.getProp(SiriusConfiguration.MAX_AKKA_MESSAGE_SIZE_KB, "1024")
+    val bufferSize = maxMessageSize * 2
+    configMap.put(s"$transportPrefix.maximum-frame-size", s"${maxMessageSize}k")
+    configMap.put(s"$transportPrefix.send-buffer-size", s"${bufferSize}k")
+    configMap.put(s"$transportPrefix.receive-buffer-size", s"${bufferSize}k")
 
     if (sslEnabled) {
       configMap.put(s"$transportPrefix.random-number-generator",

--- a/src/test/resources/sirius-akka-base.conf
+++ b/src/test/resources/sirius-akka-base.conf
@@ -25,9 +25,6 @@ common-netty-settings {
     hostname = ""
     port = 2552
 
-    # band-aid while our messages are too big :)
-    message-frame-size = 100 MiB
-
     # this is probably too liberal
     connection-timeout = 2s
 


### PR DESCRIPTION
Also, make it actually do something. We currently specify it in a
non-functioning way for the version of akka we're using. Apparently the
key for that piece of configuration changed with the versions.

128K is the default for Akka, which is how it's been de facto configured
since the last release. Keeping that default configuration here, just
making it adjustable.
