### PR TITLE
Replica should ignore out-of-date DecisionHints

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/paxos/Replica.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/paxos/Replica.scala
@@ -125,7 +125,7 @@ class Replica(localLeader: ActorRef,
           logger.warning("Received exception applying decision {}: {}", decision, t)
       }
 
-    case decisionHint @ DecisionHint(decisionHintSlotNum) =>
+    case decisionHint @ DecisionHint(decisionHintSlotNum) if decisionHintSlotNum >= slotNum =>
       slotNum = decisionHintSlotNum + 1
 
       outstandingProposals.filter((k, _) => k > decisionHintSlotNum)

--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/paxos/ReplicaTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/paxos/ReplicaTest.scala
@@ -162,6 +162,14 @@ class ReplicaTest extends NiceTest with BeforeAndAfterAll {
     }
 
     describe ("in response to a DecisionHint") {
+      it("ignores the DH if it's out of date") {
+        val localLeader = TestProbe()
+        val replica = makeReplica(localLeader.ref, 5)
+        replica ! DecisionHint(2)
+
+        assert(5 === replica.underlyingActor.slotNum)
+        localLeader.expectNoMsg()
+      }
       it("updates the slotNum") {
         val localLeader = TestProbe()
         val replica = makeReplica(localLeader.ref, 2)


### PR DESCRIPTION
Defensively check for slotNum usefulness before applying the
DecisionHint. Otherwise, if we got an old duplicate or a mis-sent
DecisionHint it could do something nasty.
