### PR TITLE
getRandomMember returns Try instead of Option

### DIFF
--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/bridge/PaxosStateBridgeTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/bridge/PaxosStateBridgeTest.scala
@@ -34,6 +34,7 @@ import com.comcast.xfinity.sirius.api.impl.Delete
 import com.comcast.xfinity.sirius.api.impl.paxos.PaxosMessages.Decision
 import com.comcast.xfinity.sirius.api.impl.bridge.PaxosStateBridge.RequestFromSeq
 import com.comcast.xfinity.sirius.api.impl.paxos.PaxosMessages.Command
+import scala.util.Success
 
 class PaxosStateBridgeTest extends NiceTest with BeforeAndAfterAll with TimedTest {
 
@@ -41,7 +42,7 @@ class PaxosStateBridgeTest extends NiceTest with BeforeAndAfterAll with TimedTes
 
   val config = new SiriusConfiguration
   val defaultMockMembershipHelper = mock[MembershipHelper]
-  doReturn(Some(TestProbe().ref)).when(defaultMockMembershipHelper).getRandomMember
+  doReturn(Success(TestProbe().ref)).when(defaultMockMembershipHelper).getRandomMember
   def makeStateBridge(startingSeq: Long,
                       stateSupActor: ActorRef = TestProbe().ref,
                       siriusSupActor: ActorRef = TestProbe().ref,

--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/membership/MembershipHelperTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/membership/MembershipHelperTest.scala
@@ -57,7 +57,7 @@ class MembershipHelperTest extends NiceTest with BeforeAndAfterAll {
         val membershipHelper: MembershipHelper = MembershipHelper(membership, localActorRef)
 
         val data = membershipHelper.getRandomMember
-        assert(data === None)
+        assert(data.isFailure)
       }
 
       it("should send back a None if the membershipMap is empty") {
@@ -65,7 +65,7 @@ class MembershipHelperTest extends NiceTest with BeforeAndAfterAll {
         val membershipHelper: MembershipHelper = MembershipHelper(membership, localActorRef)
 
         val data = membershipHelper.getRandomMember
-        assert(data === None)
+        assert(data.isFailure)
       }
 
       it("should send back a None if all values are currently None or local") {
@@ -73,7 +73,7 @@ class MembershipHelperTest extends NiceTest with BeforeAndAfterAll {
         val membershipHelper: MembershipHelper = MembershipHelper(membership, localActorRef)
 
         val data = membershipHelper.getRandomMember
-        assert(data === None)
+        assert(data.isFailure)
       }
     }
 


### PR DESCRIPTION
Try maps much more cleanly to what getRandomMember is hoping to do. This
setup models failure a little more gracefully, and will be useful in
rebuilding some of our catchup logic.
