### PR TITLE
Release 1.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@
 
 name := "sirius"
 
-version := "1.2.1-SNAPSHOT"
+version := "1.2.1"
 
 scalaVersion := "2.10.2"
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>sirius</artifactId>
     <name>Sirius</name>
     <packaging>jar</packaging>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.1</version>
     <description>The Comcast Sirius library </description>
     <url>https://github.com/Comcast/sirius</url>
     <licenses>


### PR DESCRIPTION
This release contains a fix for issue #48, where very slow networks coupled with large catchup windows could cause unbounded memory usage in cluster nodes.
# New Features

d64c17e Make akka max-frame-size configurable
00e94b0 Simplify Catchup Request logic, more config
525b321 Add MBean monitors for window, ssthresh
# Bugfixes

688699f Remove old catch-up remnants
3534071 Wire in new catch-up algorithm
229dbc7 Create CatchupActor, CatchupSupervisor
564dbb4 Increase FullSystemITest membership timeout
1457e69 Replica should ignore out-of-date DecisionHints
a3fefb9 Fix tty restoration logic in sirius-standalone
# Documentation/Project Maintenance

381384c add contributors.md file
52d8509 getRandomMember returns Try instead of Option
adf343e fix typos
49e383f Updated pom.xml to support Maven-Repo standards
689db44 Disable parallel testing
41bf952 fix travis badge
8c5f976 Small cleanup of SiriusFactory
a59f764 SiriusConfig.getProp default to call by name
9a210d4 add CLA link to contributing page
415bab1 Fix README typo
e85ea7e give credit to lazybones on NOTICE page
4ac7d93 Instructions for contributors re: CLA.
b7cab2e cleanup unit tests
2d788db Bump version to 1.2.1-SNAPSHOT
