### PR TITLE
Fix external links in Scaladocs.

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
@@ -43,8 +43,8 @@ object SiriusConfiguration {
    * the no-arg constructor of [[http://docs.oracle.com/javase/1.5.0/docs/api/java/security/SecureRandom.html java.security.SecureRandom]].
    *
    * Possible values include AES128CounterSecureRNG, AES256CounterSecureRNG, AES128CounterInetRNG,
-   * AES256CounterInetRNG, SHA1PRNG, NativePRNG. See [[http://doc.akka.io/japi/akka/2.2-M4/akka/remote/transport/netty/NettySSLSupport$.html akka.remote.transport.netty.NettySSLSupport]] for
-   * more details.
+   * AES256CounterInetRNG, SHA1PRNG. See lines 457-470 of the [[http://doc.akka.io/docs/akka/2.2.1/general/configuration.html#akka-remote akka-remote reference configuration]] for more details;
+   * this option is simply passed through to Akka by Sirius.
    */
   final val SSL_RANDOM_NUMBER_GENERATOR = "sirius.akka.ssl.rng"
 

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/paxos/PaxosSupervisor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/paxos/PaxosSupervisor.scala
@@ -28,7 +28,7 @@ object PaxosSupervisor {
   /**
    * Factory for creating children actors of PaxosSup.
    *
-   * @param membership an [[http://doc.akka.io/api/akka/2.0/akka/agent/Agent.html akka.agent.Agent]] tracking the membership of the cluster
+   * @param membership an [[http://doc.akka.io/api/akka/2.2.1/#akka.agent.Agent Agent]] tracking the membership of the cluster
    * @param startingSeq the sequence number at which this node will begin issuing/acknowledging
    * @param performFun function specified by
    *          [[com.comcast.xfinity.sirius.api.impl.paxos.Replica.PerformFun]], applied to


### PR DESCRIPTION
This addresses issue #41, by just taking the path of least
resistance and entering explicit URLs for the three
external references we currently have.
