### PR TITLE
start a scout if remote leadership fails

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/paxos/Leader.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/paxos/Leader.scala
@@ -241,7 +241,7 @@ class Leader(membership: MembershipHelper,
         startLeaderWatcher()
 
       case Failure(_) =>
-      // XXX really hope this doesn't happen, right after we've gotten the Preempted message with a new id in it
+        startScout()
     }
   }
 


### PR DESCRIPTION
when handling a leadership change, it is possible that sirius can fail
to resolve a remote reference to a new leader. This has been observed
during rolling restarts and on commodity hardware. If this happens and a
scout is not started, the node's leader will never resolve (ie remain
unknown) and will be unable to participate properly in its cluster.
