### PR TITLE
add periodic state check for leader state

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
@@ -241,6 +241,11 @@ object SiriusConfiguration {
   final val LOG_REQUEST_FREQ_SECS = "sirius.log-request.freq-secs"
 
   /**
+   * How long (in seconds) to periodically check leader state
+   */
+  final val CHECK_LEADER_STATE_FREQ_SECS = "sirius.check-leader-state.freq-secs"
+
+  /**
    * How long (in milliseconds) for requests in SiriusImpl to wait for a response from
    * the underlying actor (int)
    */

--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/paxos/LeaderTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/paxos/LeaderTest.scala
@@ -25,14 +25,14 @@ import collection.immutable.SortedMap
 import java.util.{TreeMap => JTreeMap}
 import scala.collection.JavaConversions._
 import com.comcast.xfinity.sirius.api.impl.paxos.PaxosMessages._
-import scala.Some
 import com.comcast.xfinity.sirius.api.impl.Delete
 import com.comcast.xfinity.sirius.api.impl.paxos.LeaderWatcher.{Close, LeaderGone}
 import com.comcast.xfinity.sirius.util.{AkkaExternalAddressResolver, RichJTreeMap}
-import com.comcast.xfinity.sirius.api.impl.paxos.Leader.{Remote, Local, Unknown, ChildProvider}
+import com.comcast.xfinity.sirius.api.impl.paxos.Leader._
 import com.comcast.xfinity.sirius.api.SiriusConfiguration
 import com.comcast.xfinity.sirius.api.impl.membership.MembershipHelper.ClusterInfo
 import com.comcast.xfinity.sirius.api.impl.membership.MembershipHelper
+import scala.concurrent.duration.FiniteDuration
 
 
 class LeaderTest extends NiceTest with TimedTest with BeforeAndAfterAll {
@@ -68,7 +68,7 @@ class LeaderTest extends NiceTest with TimedTest with BeforeAndAfterAll {
                                        replyTo: ActorRef)(implicit context: ActorContext) = startWatcherFun
     }
     TestActorRef(
-      new Leader(membership, startingSeqNum, childProvider, helper, testConfig)
+      new Leader(membership, startingSeqNum, childProvider, helper, testConfig, FiniteDuration(1, "hour"))
     )
   }
 
@@ -371,6 +371,41 @@ class LeaderTest extends NiceTest with TimedTest with BeforeAndAfterAll {
 
         electedLeader.expectMsg(Propose(1L, command))
         electedLeader.expectMsg(Propose(3L, command2))
+      }
+    }
+
+    describe("when receiving a StateCheck message") {
+      describe("and electedLeader is Unknown") {
+        it("should start a scout") {
+          var scoutStarts = 0
+          val leaderRef = makeMockedUpLeader(
+            startScoutFun = {
+              scoutStarts += 1
+              TestProbe().ref
+            }
+          )
+
+          leaderRef ! Leader.StateCheck
+          //once for instantiation of leader and another for state check
+          assert(waitForTrue(scoutStarts == 2, 2000, 25))
+        }
+      }
+      describe("and electedLeader is Remote but the watcher is None") {
+        it("should start a watcher") {
+          var watchLeaderStarts = 0
+          val leaderRef = makeMockedUpLeader(
+            startWatcherFun = {
+              watchLeaderStarts += 1
+              TestProbe().ref
+            }
+          )
+
+          val leader = leaderRef.underlyingActor
+          leader.electedLeader = Remote(TestProbe().ref, Ballot.empty)
+          leaderRef ! Leader.StateCheck
+
+          assert(waitForTrue(watchLeaderStarts == 1, 2000, 25))
+        }
       }
     }
 


### PR DESCRIPTION
Under certain rare conditions the Leader can be in a corrupted state
which takes some time to resolve. A periodic state check has been
added for the following:
- if the elected leader is unknown, a scout is started
- if the elected leader is remote, but there is no leader watcher, a
  leader watcher is started
