### PR TITLE
Gate failed connections for 200ms

### DIFF
--- a/src/main/resources/sirius-akka-base.conf
+++ b/src/main/resources/sirius-akka-base.conf
@@ -23,6 +23,7 @@ akka {
     watch-failure-detector {
       acceptable-heartbeat-pause = 10 s
     }
+    retry-gate-closed-for = 0.2 s
   }
 }
 


### PR DESCRIPTION
If a connection fails, block connections to that same node for 200ms.
Despite the gate-window/max-retries defaults, we were still seeing
floods of reconnect messages whenever an association failed. This 
change brings the reconnect rate down to something far more 
manageable.

Additionally, this is in line with the changes akka makes between 2.2
and 2.3. The automatic retry logic will be removed in favor of the
`retry-gate-closed-for` setting -- so this change looks forward.
