### PR TITLE
Release 1.2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@
 
 name := "sirius"
 
-version := "1.2.2-SNAPSHOT"
+version := "1.2.2"
 
 scalaVersion := "2.10.2"
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>sirius</artifactId>
     <name>Sirius</name>
     <packaging>jar</packaging>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.2.2</version>
     <description>The Comcast Sirius library </description>
     <url>https://github.com/Comcast/sirius</url>
     <licenses>


### PR DESCRIPTION
A number of fixes in this release address issues arising from the akka upgrade
in 1.2.0.
# Fixes

7574dfc Do not send out-of-order events to StateSupervisor
d28af99 prune dead members from memberAgents
2fcd04c add periodic state check for leader state
a770ea1 Return false for timed-out `isOnline` calls
e424df9 start a scout if remote leadership fails
# Default configuration changes

7c6e757 Gate failed connections for 200ms
391e8a2 Adjust values to line up with 2.3 defaults
b547e8c Disable quarantining, dial back health sensitivity
3880065 Lessen default LeadershipPing interval
# New Features

834c0fa De-stringify non-string config values
3ad2289 Introduce .getDouble and .getInt to SiriusConfig
232b7cd More precise downcast for .getProp
f6e2f1f Augment MembershipActor monitoring
# Documentation

a529dfc Updated external documentation links.
8679d6e Fix external links in Scaladocs.
8a5c865 Add links for issues and questions.
# Project Maintenance

4f43707 use bintray for dependency resolution
616900c Upgrade to sbt 0.13.2
