### PR TITLE
Add liveness entry on resolution

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/membership/MembershipActor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/membership/MembershipActor.scala
@@ -147,7 +147,6 @@ class MembershipActor(membershipAgent: Agent[Map[String, Option[ActorRef]]],
 
     expired.foreach { case (path, _) =>
       membershipAgent send (_ + (path -> None))
-      membershipRoundTripMap -= path
       lastLivenessDetectedMap -= path
     }
 

--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/membership/MembershipActorTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/membership/MembershipActorTest.scala
@@ -137,8 +137,6 @@ class MembershipActorTest extends NiceTest with TimedTest {
         "Valid reference was unexpectedly removed")
       assert(waitForTrue(membershipAgent.get()("foo") == None, 2000, 100), "foo is defined but is not None.")
       assert(!underTest.underlyingActor.lastLivenessDetectedMap.contains("foo"), "foo should have been deleted from ping map")
-      assert(!underTest.underlyingActor.membershipRoundTripMap.contains("foo"),
-        "foo should have been deleted from roundtrip map")
     }
 
     it("should call update membership if there is a dead actor when PingMembership is received") {


### PR DESCRIPTION
MembershipActor tracks liveness (to some extent) of remote nodes by
relying on a Ping/Pong mechanism. It can evict dead-seeming nodes from
the MembershipMap when they haven't been "active" in a long time -- that
is, when it hasn't received a Pong for one of its Pings.

However, there's another time where we get information about ref
liveness, and that's on resolution. Currently there's an edge case where
a node can get a reference and not yet have any liveness data. Then, if
the ref immediately goes stale, there will be no way to evict it due to
unresponsiveness.

With this change, every "active" ref in the membership map should have
a corresponding last-liveness metric at all times.
