### PR TITLE
Release 1.2.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@
 
 name := "sirius"
 
-version := "1.2.3-SNAPSHOT"
+version := "1.2.3"
 
 scalaVersion := "2.10.2"
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>sirius</artifactId>
     <name>Sirius</name>
     <packaging>jar</packaging>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.2.3</version>
     <description>The Comcast Sirius library </description>
     <url>https://github.com/Comcast/sirius</url>
     <licenses>


### PR DESCRIPTION
Contains only a minor fix for 1.2.2, addressing an issue where a node could lose its
reference to a remote node via expired actor pruning, but not be able to recover.
# Fixes

ba7727e Don't remove MembershipRoundTrip entry on expire
7df7226 Add liveness entry on resolution
