### PR TITLE
Catchup succeeds despite large compaction holes

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisor.scala
@@ -50,7 +50,8 @@ object CatchupSupervisor {
     val timeoutCoeff = config.getDouble(SiriusConfiguration.CATCHUP_TIMEOUT_INCREASE_PER_EVENT, .01)
     val timeoutConst = config.getDouble(SiriusConfiguration.CATCHUP_TIMEOUT_BASE, 1.0)
     val maxWindowSize = config.getInt(SiriusConfiguration.CATCHUP_MAX_WINDOW_SIZE, 1000)
-    val startingSSThresh = config.getInt(SiriusConfiguration.CATCHUP_DEFAULT_SSTHRESH, 500)
+    // must ensure ssthresh <= maxWindowSize
+    val startingSSThresh = Math.min(maxWindowSize, config.getInt(SiriusConfiguration.CATCHUP_DEFAULT_SSTHRESH, 500))
     Props(new CatchupSupervisor(membershipHelper, timeoutCoeff, timeoutConst, maxWindowSize, startingSSThresh, config))
   }
 }

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/bridge/PaxosStateBridge.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/bridge/PaxosStateBridge.scala
@@ -161,11 +161,14 @@ class PaxosStateBridge(startingSeq: Long,
   }
 
   private def applySubrange(subrange: PopulatedSubrange) {
-    // for each useful event, send it to the stateSupervisor and update nextSeq
+    // for each useful event, send it to the stateSupervisor
     subrange.events.dropWhile(_.sequence < nextSeq).foreach {
       case event =>
         stateSupervisor ! event
-        nextSeq = event.sequence + 1
+    }
+    // update nextSeq based on the declared rangeEnd, no matter what events were actually included
+    if (subrange.rangeEnd >= nextSeq) {
+      nextSeq = subrange.rangeEnd + 1
     }
     // dump out of the buffer events that no longer matter
     eventBuffer.dropWhile((slot, _) => slot < nextSeq)

--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/bridge/PaxosStateBridgeTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/bridge/PaxosStateBridgeTest.scala
@@ -179,6 +179,20 @@ class PaxosStateBridgeTest extends NiceTest with BeforeAndAfterAll with TimedTes
       underTest ! CompleteSubrange(10, 10, List[OrderedEvent]())
       catchupProbe.expectMsgClass(classOf[ContinueCatchup])
     }
+    it("should update nextSeq for a CompleteSubrange regardless of the updates contained") {
+      val catchupProbe = TestProbe()
+      val underTest = makeStateBridge(10, catchupSupervisor = catchupProbe.ref)
+
+      underTest ! InitiateCatchup
+      catchupProbe.expectMsg(InitiateCatchup(10))
+
+      assert(10 === underTest.underlyingActor.nextSeq)
+
+      underTest ! CompleteSubrange(10, 11, List[OrderedEvent]())
+      catchupProbe.expectMsgClass(classOf[ContinueCatchup])
+
+      assert(12 === underTest.underlyingActor.nextSeq)
+    }
   }
   describe("upon receiving a PartialSubrange") {
     it("should ask the CatchupSupervisor to stop catchup") {


### PR DESCRIPTION
Previously, compaction would stall and eventually fail if sufficiently
large compaction holes existed after and including the requested
sequence number. Specifically, if there were no updates within
MAX_WINDOW_SIZE of the requested sequence number, catchup would not be
able to make progress. This is a small change that will update nextSeq
properly in the face of empty catchup Subranges, allowing a follower to
recognize compaction holes and move on with its life.

Also added a couple of a FullSystemITests that demonstrate this problem.