### PR TITLE
Purge old DELETEs during live compaction

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
@@ -195,6 +195,13 @@ object SiriusConfiguration {
   final val COMPACTION_SCHEDULE_MINS = "sirius.log.compaction-schedule-mins"
 
   /**
+   * The maximum age for a Delete in hours that remains after compaction.  Deletes
+   * that are older than this age will be purged during compaction.  The default
+   * is that Deletes will not be purged during compaction.
+   */
+  final val COMPACTION_MAX_DELETE_AGE_HOURS = "sirius.log.compaction-max-delete-age-hours"
+
+  /**
    * Name of the sirius supervisor, typically we will not change this,
    * but it's here just in case (string)
    */

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
@@ -148,7 +148,9 @@ class SegmentedUberStoreTest extends NiceTest {
     }
 
     it ("should split after the specified number of events have been written") {
-      val underTest = new SegmentedUberStore(dir, 10L)
+      val siriusConfig = new SiriusConfiguration()
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val underTest = new SegmentedUberStore(dir, 10L, segmentedCompactor)
 
       assert("1" === underTest.liveDir.name)
       writeUberStoreEvents(underTest, Range.inclusive(1, 10).toList)
@@ -195,7 +197,9 @@ class SegmentedUberStoreTest extends NiceTest {
 
   describe("compact") {
     it ("should perform a do-nothing compact of a single Segment, if |readOnlyDirs| == 1") {
-      val underTest = new SegmentedUberStore(dir, 10L)
+      val siriusConfig = new SiriusConfiguration()
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val underTest = new SegmentedUberStore(dir, 10L, segmentedCompactor)
 
       writeUberStoreEvents(underTest, Range.inclusive(1, 10).toList)
       underTest.compactAll()
@@ -206,7 +210,9 @@ class SegmentedUberStoreTest extends NiceTest {
     }
 
     it ("should perform a real compact of Segment 1 if Segment 2 is read-only") {
-      val underTest = new SegmentedUberStore(dir, 10L)
+      val siriusConfig = new SiriusConfiguration()
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val underTest = new SegmentedUberStore(dir, 10L, segmentedCompactor)
 
       writeUberStoreEvents(underTest, Range.inclusive(1, 10).toList)
       writeUberStoreEvents(underTest, Range.inclusive(6, 15).toList)


### PR DESCRIPTION
This change is to address Issue 112, 'Old deletes need to be purged
during Compaction'.

It adds the ability to specify a
sirius.log.compaction-max-delete-age-hours configuration property to
cause old Delete events to be purged during live compaction.

The configuration property defaults to a very large value, so by default
Delete events will not be purged.

It also adds an option to WalTool to purge old Deletes, along with
other options for old PUTs.