### PR TITLE
Add backup_wal.sh and remove compacting dirs

### DIFF
--- a/src/main/bin/backup_wal.sh
+++ b/src/main/bin/backup_wal.sh
@@ -23,6 +23,7 @@ if [ $# -ne 1 ]
 then
   echo "Usage: `basename $0` <base_dir>" >&2
   echo "  base_dir is the directory that contains the uberstore directory to be backed up." >&2
+  echo "  WARNING - Do not execute this script while Sirius is running." >&2
   exit 1
 fi
 

--- a/src/main/bin/backup_wal.sh
+++ b/src/main/bin/backup_wal.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2012-2014 Comcast Cable Communications Management, LLC
+# Copyright 2012-2015 Comcast Cable Communications Management, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,20 +19,11 @@ function die() {
   exit 1
 }
 
-function die_happy() {
-  echo "$@" >&2
-  exit 0
-}
-
 if [ $# -ne 1 ]
 then
   echo "Usage: `basename $0` <base_dir>" >&2
-  echo "  base_dir is the directory that contains the uberstore directory to be compacted." >&2
+  echo "  base_dir is the directory that contains the uberstore directory to be backed up." >&2
   exit 1
-fi
-
-if [ "x$JAVA_OPTS" == "x" ]; then
-    JAVA_OPTS="-Xms8g -Xmx20g"
 fi
 
 UBERSTORE_BASE=$1
@@ -41,10 +32,6 @@ WALTOOL_BASE=$(cd $WALTOOL_BASE && pwd)
 
 WAL_DIR=$UBERSTORE_BASE/uberstore
 BACKUP_WAL_DIR=$UBERSTORE_BASE/uberstore-backup
-COMPACTED_WAL_DIR=$UBERSTORE_BASE/uberstore-compacted
-
-echo "Removing any existing compacted logs from $COMPACTED_WAL_DIR"
-rm -rf $COMPACTED_WAL_DIR || die "Error removing existing compacted log."
 
 echo "Removing any existing backup logs from $BACKUP_WAL_DIR"
 rm -rf $BACKUP_WAL_DIR || die "Error removing existing backup log."
@@ -55,17 +42,4 @@ rm -rf $WAL_DIR/*.compacting || die "Error removing .compacting directories."
 echo "Copying $WAL_DIR to $BACKUP_WAL_DIR"
 cp -r $WAL_DIR $BACKUP_WAL_DIR || die "Error backing up log."
 
-$WALTOOL_BASE/waltool is-legacy $WAL_DIR || die_happy "Will not compact non-legacy WAL, exiting quietly."
-
-echo "Compacting $WAL_DIR into $COMPACTED_WAL_DIR"
-JAVA_OPTS="$JAVA_OPTS" $WALTOOL_BASE/waltool compact two-pass $WAL_DIR $COMPACTED_WAL_DIR || die "Error compacting log."
-
-echo "Copying $COMPACTED_WAL_DIR to $WAL_DIR"
-for f in `ls -1 $COMPACTED_WAL_DIR`
-do
-  echo "  Copying $f"
-  # This is being done with cat to preserve ownership and permissions.
-  cat $COMPACTED_WAL_DIR/$f > $WAL_DIR/$f || die "Error copying log into place."
-done
-
-echo "Compaction Completed"
+echo "Backup Completed"

--- a/src/main/bin/compact_wal.sh
+++ b/src/main/bin/compact_wal.sh
@@ -28,6 +28,7 @@ if [ $# -ne 1 ]
 then
   echo "Usage: `basename $0` <base_dir>" >&2
   echo "  base_dir is the directory that contains the uberstore directory to be compacted." >&2
+  echo "  WARNING - Do not execute this script while Sirius is running." >&2
   exit 1
 fi
 


### PR DESCRIPTION
This change adds a new script, backup_wal.sh.  It is the equivalent of
compact_wal.sh, however it does not try to do any compacting.  It simply
makes a backup of uberstore.

The change also adds a step to both compact_wal.sh and backup_wal.sh to
remove any .compacting directories that exist.  These directories are
created during live compaction and are temporary.  If Sirius is stopped
during compaction, they may exist and if the timing is right they can
almost double the size of the uberstore.

They would be deleted when the first compaction starts anyway, so they
serve no useful purpose and can be deleted to save disk space.