### PR TITLE
Implement Internal Compaction

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/Segment.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/Segment.scala
@@ -48,13 +48,15 @@ object Segment {
     val dataFile = new File(location, "data")
     val indexFile = new File(location, "index")
     val compactionFlagFile = new File(location, "keys-collected")
+    val internalCompactionFlagFile = new File(location, "internally-compacted")
 
     val data = UberDataFile(dataFile.getAbsolutePath)
     val index = DiskOnlySeqIndex(indexFile.getAbsolutePath)
     val compactionFlag = FlagFile(compactionFlagFile.getAbsolutePath)
+    val internalCompactionFlag = FlagFile(internalCompactionFlagFile.getAbsolutePath)
 
     repairIndex(index, data)
-    new Segment(location, location.getName, data, index, compactionFlag)
+    new Segment(location, location.getName, data, index, compactionFlag, internalCompactionFlag)
   }
 
   /**
@@ -94,7 +96,8 @@ object Segment {
  * @param dataFile the UberDataFile to store data in
  * @param index the SeqIndex to use
  */
-class Segment private[uberstore](val location: File, val name: String, dataFile: UberDataFile, index: SeqIndex, compactionFlag: FlagFile) {
+class Segment private[uberstore](val location: File, val name: String, dataFile: UberDataFile,
+                                 index: SeqIndex, compactionFlag: FlagFile, internalCompactionFlag: FlagFile) {
 
   /**
    * Get the number of entries written to the Segment
@@ -195,4 +198,19 @@ class Segment private[uberstore](val location: File, val name: String, dataFile:
     compactionFlag.set(value = applied)
   }
 
+  /**
+   * Has this segment been internally compacted?
+   *
+   * @return true if internal compaction is completed, false otherwise
+   */
+  def isInternallyCompacted = internalCompactionFlag.value
+
+  /**
+   * Set the internally-compacted flag
+   *
+   * @param compacted the value of the flag
+   */
+  def setInternallyCompacted(compacted: Boolean) {
+    internalCompactionFlag.set(compacted)
+  }
 }

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactor.scala
@@ -100,6 +100,7 @@ private [segmented] class SegmentedCompactor(maxDeleteAgeMillis: Long) {
       case _ => // nothing
     }
 
+    compactInto.setApplied(toCompact.isApplied)
     compactInto.setInternallyCompacted(compacted = true)
     compactInto.close()
 

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactor.scala
@@ -207,7 +207,8 @@ private [segmented] class SegmentedCompactor(maxDeleteAgeMillis: Long) {
     left.foreach(target.writeEntry)
     right.foreach(target.writeEntry)
     target.setApplied(applied = left.isApplied && right.isApplied)
-    target.setInternallyCompacted(compacted = false)
+    target.setInternallyCompacted(left.isApplied && left.isInternallyCompacted &&
+                                  right.isApplied && right.isInternallyCompacted)
     target.close()
   }
 

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactor.scala
@@ -21,6 +21,7 @@ import com.comcast.xfinity.sirius.api.impl.{Delete, OrderedEvent}
 import scalax.file.Path
 import java.io.File
 import annotation.tailrec
+import java.util
 
 object SegmentedCompactor {
   val COMPACTING_SUFFIX = ".compacting"
@@ -64,12 +65,46 @@ private [segmented] class SegmentedCompactor(maxDeleteAgeMillis: Long) {
   }
 
   /**
+   * Find all segments that have not been internally compacted, so that they might be compacted.
+   *
+   * @param segments read only segments to filter on
+   * @return list of segments that should be internally compacted
+   */
+  def findInternalCompactionCandidates(segments: List[Segment]): List[Segment] = segments.filterNot(_.isInternallyCompacted)
+
+  /**
    * If one exists, finds a segment in the supplied list that can be applied in compaction.
    *
    * @param segments list of all candidate segments
    * @return List of all Segments that could be compacted against
    */
   def findCompactableSegments(segments: List[Segment]): List[Segment] = segments.filterNot(_.isApplied)
+
+  /**
+   * Internally compact a segment, essentially removing all updates for a given key *except* for the last
+   * one, in sequence-number order.
+   *
+   * @param toCompact segment to internally compact
+   * @return location of compacted segment
+   */
+  def compactInternally(toCompact: Segment): String = {
+    val compactInto = Segment(toCompact.location.getParentFile, toCompact.name + SegmentedCompactor.COMPACTING_SUFFIX)
+    val keySequenceMap = new util.HashMap[String, Long]
+    toCompact.foreach { event =>
+      keySequenceMap.put(event.request.key, event.sequence)
+    }
+
+    // only write events if they're the most recent for a given key inside the segment
+    toCompact.foreach {
+      case event if keySequenceMap.get(event.request.key) == event.sequence => compactInto.writeEntry(event)
+      case _ => // nothing
+    }
+
+    compactInto.setInternallyCompacted(compacted = true)
+    compactInto.close()
+
+    compactInto.location.getAbsolutePath
+  }
 
   /**
    * Compact supplied list against a single segment. This method will filter out segments
@@ -94,10 +129,16 @@ private [segmented] class SegmentedCompactor(maxDeleteAgeMillis: Long) {
     val keys = toCompactAgainst.keys
     segments.foldLeft(Map[Segment, String]())(
       (map, toCompact) => {
+        // toCompact MUST be internally compacted or we risk losing data
+        if (!toCompact.isInternallyCompacted) {
+          throw new IllegalStateException("Attempted to compact against a non-internally compacted Segment.")
+        }
+
         val compactInto = Segment(toCompact.location.getParentFile, toCompact.name + SegmentedCompactor.COMPACTING_SUFFIX)
         compactSegment(keys, toCompact, compactInto)
 
         compactInto.setApplied(toCompact.isApplied)
+        compactInto.setInternallyCompacted(toCompact.isInternallyCompacted)
         compactInto.close()
 
         map + (toCompact -> compactInto.location.getAbsolutePath)
@@ -165,6 +206,7 @@ private [segmented] class SegmentedCompactor(maxDeleteAgeMillis: Long) {
     left.foreach(target.writeEntry)
     right.foreach(target.writeEntry)
     target.setApplied(applied = left.isApplied && right.isApplied)
+    target.setInternallyCompacted(compacted = false)
     target.close()
   }
 

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactor.scala
@@ -76,22 +76,22 @@ private [segmented] class SegmentedCompactor(maxDeleteAgeMillis: Long) {
    * that should not be compacted (i.e., segments in the list occurring after toCompact
    * in time)
    *
-   * @param toCompact segment to compact against
+   * @param toCompactAgainst segment to compact against
    * @param allSegments list of segments to be compacted
    * @return Map of (old Segment -> compacted Segment location)
    */
-  def compactAgainst(toCompact: Segment, allSegments: List[Segment]): Map[Segment, String] =
-    compactSegments(toCompact, allSegments.filter(_.name.toLong < toCompact.name.toLong))
+  def compactAgainst(toCompactAgainst: Segment, allSegments: List[Segment]): Map[Segment, String] =
+    compactSegments(toCompactAgainst, allSegments.filter(_.name.toLong < toCompactAgainst.name.toLong))
 
   /**
    * Compact all provided Segments against the provided Segment. There is no filtering in this method: only
    * provide the Segments you want compacted.
    *
-   * @param toCompact Segment to compact against
+   * @param toCompactAgainst Segment to compact against
    * @param segments segments to be compacted
    */
-  private def compactSegments(toCompact: Segment, segments: List[Segment]): Map[Segment, String] = {
-    val keys = toCompact.keys
+  private def compactSegments(toCompactAgainst: Segment, segments: List[Segment]): Map[Segment, String] = {
+    val keys = toCompactAgainst.keys
     segments.foldLeft(Map[Segment, String]())(
       (map, toCompact) => {
         val compactInto = Segment(toCompact.location.getParentFile, toCompact.name + SegmentedCompactor.COMPACTING_SUFFIX)

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
@@ -202,11 +202,16 @@ class SegmentedUberStore private[segmented] (base: File, eventsPerSegment: Long,
     merge()
   }
 
-  def size():Long = {
+  /**
+   * Calculates size of the SiriusLog.
+   *
+   * @return a measure of size of the SiriusLog
+   */
+  def size: Long = {
     def recursiveListFiles(f: File): Array[File] = {
-               val these = f.listFiles
-                these ++ these.filter(_.isDirectory).flatMap(recursiveListFiles)
-        }
+      val these = f.listFiles
+      these ++ these.filter(_.isDirectory).flatMap(recursiveListFiles)
+    }
     recursiveListFiles(base).filter(_.isFile).map(_.length).sum
   }
 

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
@@ -193,6 +193,8 @@ class SegmentedUberStore private[segmented] (base: File, eventsPerSegment: Long,
     }
 
   /**
+   * For each non-internally-compacted segment, internally compact it.
+   *
    * For each unapplied Segment, compact previous segments according to its keys,
    * continuing as long as there are unapplied segments. When Segments have been
    * applied, merge any adjacent undersized segments.
@@ -219,6 +221,11 @@ class SegmentedUberStore private[segmented] (base: File, eventsPerSegment: Long,
    * Compact readOnlyDirs until they can be compacted no longer.
    */
   private[segmented] def compactAll() {
+    for (toCompact <- segmentedCompactor.findInternalCompactionCandidates(readOnlyDirs)) {
+      val compactedLocation = segmentedCompactor.compactInternally(toCompact)
+      replaceSegment(toCompact, compactedLocation) // mutates readOnlyDirs
+    }
+
     for (toCompact <- segmentedCompactor.findCompactableSegments(readOnlyDirs)) {
       val compactionMap = segmentedCompactor.compactAgainst(toCompact, readOnlyDirs)
       replaceSegments(compactionMap) // mutates readOnlyDirs

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactorTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactorTest.scala
@@ -128,7 +128,80 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
     }
   }
 
+  describe("compactInternally") {
+    it("should remove earlier entries for duplicate keys within the segment") {
+      val segment = Segment(dir, "1")
+      List(
+        OrderedEvent(1L, 0L, Delete("1")),
+        OrderedEvent(2L, 0L, Delete("2")),
+        OrderedEvent(3L, 0L, Delete("2")),
+        OrderedEvent(4L, 0L, Delete("2")),
+        OrderedEvent(5L, 0L, Delete("5"))
+      ).foreach(segment.writeEntry)
+
+      val underTest = SegmentedCompactor(new SiriusConfiguration())
+      val compacted = makeSegment(underTest.compactInternally(segment))
+
+      val seqs = compacted.foldLeft(List[Long]())((acc, evt) => evt.sequence +: acc).reverse
+      assert(List(1L, 4L, 5L) === seqs)
+      assert("1 2 5" === listEvents(compacted))
+    }
+    it("should do nothing if there are no duplicate keys") {
+      val segment = Segment(dir, "1")
+      writeEvents(segment, List(1L, 2L, 3L, 4L))
+
+      val underTest = SegmentedCompactor(new SiriusConfiguration())
+      val compacted = makeSegment(underTest.compactInternally(segment))
+      assert("1 2 3 4" === listEvents(compacted))
+    }
+    it("should set the internallyCompacted flag to true") {
+      val segment = Segment(dir, "1")
+
+      val underTest = SegmentedCompactor(new SiriusConfiguration())
+      val compacted = makeSegment(underTest.compactInternally(segment))
+
+      assert(true === compacted.isInternallyCompacted)
+    }
+  }
+
+  describe("findInternalCompactionCandidates") {
+    it("should return an empty list if all segments are internally compacted") {
+      val (one, two, three) = (Segment(dir, "1"), Segment(dir, "2"), Segment(dir, "3"))
+      one.setInternallyCompacted(compacted = true)
+      two.setInternallyCompacted(compacted = true)
+      three.setInternallyCompacted(compacted = true)
+
+      val underTest = SegmentedCompactor(new SiriusConfiguration())
+      val candidates = underTest.findInternalCompactionCandidates(List(one, two, three))
+
+      assert(List() === candidates)
+    }
+    it("should return only the segments that have not been internally compacted") {
+      val (one, two, three) = (Segment(dir, "1"), Segment(dir, "2"), Segment(dir, "3"))
+      one.setInternallyCompacted(compacted = true)
+      two.setInternallyCompacted(compacted = false)
+      three.setInternallyCompacted(compacted = true)
+
+      val underTest = SegmentedCompactor(new SiriusConfiguration())
+      val candidates = underTest.findInternalCompactionCandidates(List(one, two, three))
+
+      assert(List(two) === candidates)
+    }
+  }
+
   describe("compactAgainst") {
+    it("should fail if one of the segments to compact has not been internally compacted") {
+      val first = Segment(dir, "1")
+      val second = Segment(dir, "2")
+      val segments = List(first)
+
+      first.setInternallyCompacted(compacted = false)
+
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      intercept[IllegalStateException] {
+        segmentedCompactor.compactAgainst(second, segments)
+      }
+    }
     it("should preserve a false isApplied flag when a segment is compacted") {
       val first = Segment(dir, "1")
       val second = Segment(dir, "2")
@@ -136,6 +209,7 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
 
       first.setApplied(applied = false)
+      first.setInternallyCompacted(compacted = true)
       val segmentedCompactor = SegmentedCompactor(siriusConfig)
       val compactionMap = segmentedCompactor.compactAgainst(second, segments)
       assert(false === makeSegment(compactionMap(first)).isApplied)
@@ -148,6 +222,7 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
 
       first.setApplied(applied = true)
+      first.setInternallyCompacted(compacted = true)
       val segmentedCompactor = SegmentedCompactor(siriusConfig)
       val compactionMap = segmentedCompactor.compactAgainst(second, segments)
       assert(true === makeSegment(compactionMap(first)).isApplied)
@@ -176,6 +251,7 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       val segments = List(first, second, third)
 
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
+      segments.foreach(_.setInternallyCompacted(compacted = true))
 
       val segmentedCompactor = SegmentedCompactor(siriusConfig)
       val compactionMap = segmentedCompactor.compactAgainst(second, segments)
@@ -192,6 +268,7 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       val segments = List(first, second, third)
 
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
+      segments.foreach(_.setInternallyCompacted(compacted = true))
 
       val segmentedCompactor = SegmentedCompactor(siriusConfig)
       val compactionMap = segmentedCompactor.compactAgainst(third, segments)
@@ -208,6 +285,7 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       val segments = List(third, second, first)
 
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
+      segments.foreach(_.setInternallyCompacted(compacted = true))
 
       val segmentedCompactor = SegmentedCompactor(siriusConfig)
       val compactionMap = segmentedCompactor.compactAgainst(third, segments)
@@ -224,6 +302,7 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
       writeEvents(first, List(1L, 2L, 3L, 4L))
       writeEvents(second, List(3L, 4L, 5L, 6L))
+      segments.foreach(_.setInternallyCompacted(compacted = true))
 
       val segmentedCompactor = SegmentedCompactor(siriusConfig)
       val compactionMap = segmentedCompactor.compactAgainst(second, segments)
@@ -239,6 +318,7 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
       writeEvents(first, List(1L, 2L, 3L, 4L))
       writeEvents(second, List(1L, 2L, 3L, 4L))
+      segments.foreach(_.setInternallyCompacted(compacted = true))
 
       val segmentedCompactor = SegmentedCompactor(siriusConfig)
       val compactionMap = segmentedCompactor.compactAgainst(second, segments)
@@ -260,6 +340,7 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
     writeEvents(first, List(1L), twoHoursAgo) // This one should be compacted out due to age.
     writeEvents(first, List(2L, 3L, 4L), now)
     writeEvents(second, List(3L, 4L, 5L, 6L), now)
+    segments.foreach(_.setInternallyCompacted(compacted = true))
 
     val siriusConfigWithMaxAge = new SiriusConfiguration()
     siriusConfigWithMaxAge.setProp(SiriusConfiguration.COMPACTION_MAX_DELETE_AGE_HOURS, 1)
@@ -282,6 +363,7 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
     writeEvents(first, List(1L), twoHoursAgo)
     writeEvents(first, List(2L, 3L, 4L), now)
     writeEvents(second, List(3L, 4L, 5L, 6L), now)
+    segments.foreach(_.setInternallyCompacted(compacted = true))
 
     val siriusConfigWithMaxAge = new SiriusConfiguration()
     val nowInHours = now / (60L * 60 * 1000)
@@ -384,6 +466,17 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       segmentedCompactor.mergeSegments(left, right, target)
 
       assert(false === Segment(target).isApplied)
+    }
+    it("should set the new segment's isInternallyCompacted flag to false") {
+      val (left, right) = (Segment(dir, "1"), Segment(dir, "2"))
+      left.setInternallyCompacted(compacted = true)
+      right.setInternallyCompacted(compacted = true)
+      val target = new File(dir, "1-2.merged")
+
+      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      segmentedCompactor.mergeSegments(left, right, target)
+
+      assert(false === Segment(target).isInternallyCompacted)
     }
   }
 }

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactorTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactorTest.scala
@@ -162,6 +162,15 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
       assert(true === compacted.isInternallyCompacted)
     }
+    it("should preserve the keys-applied flag") {
+      val segment = Segment(dir, "1")
+      segment.setApplied(applied = true)
+
+      val underTest = SegmentedCompactor(new SiriusConfiguration())
+      val compacted = makeSegment(underTest.compactInternally(segment))
+
+      assert(true === compacted.isApplied)
+    }
   }
 
   describe("findInternalCompactionCandidates") {


### PR DESCRIPTION
Add internal compaction to existing live compaction workflow. Previous
compaction only eliminated updates from a given segment whose keys exist
in a future segment. Here we add the ability to eliminate updates from a
given segment whose keys exist later in that same segment.

This is an optimization that, for some types of update profile, could
save a significant amount of WAL space and startup time.

Additionally, this is *strictly* necessary for anyone using the new
functionality that will purge old DELETEs from the WAL during
compaction.

This addresses issue #117