### PR TITLE
Release v1.2.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@
 
 name := "sirius"
 
-version := "1.2.6-SNAPSHOT"
+version := "1.2.6"
 
 scalaVersion := "2.10.2"
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>sirius</artifactId>
     <name>Sirius</name>
     <packaging>jar</packaging>
-    <version>1.2.6-SNAPSHOT</version>
+    <version>1.2.6</version>
     <description>The Comcast Sirius library </description>
     <url>https://github.com/Comcast/sirius</url>
     <licenses>


### PR DESCRIPTION
Includes internal compaction, which fixes #117. This version should be
used exclusively over v1.2.5 because of #117.

The combination of internal segment compaction and stale delete purges
could potentially save significant disk space and startup time for some
update profiles.

Enhancements
======
10fbcdf Implement Internal Compaction