### PR TITLE
Rev version to 2.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@
 
 name := "sirius"
 
-version := "1.2.7-SNAPSHOT"
+version := "2.0.0"
 
 scalaVersion := "2.11.8"
 


### PR DESCRIPTION
Major version bump due major library compatibility changes. 2.0.0+ is
compatible only with java 1.8+ and Scala 2.11+.

Changes:
* 8bc9198 Remove pom file; all-sbt build (PR #128)
* f8fbbae Fix broken headings in Markdown files (PR #127)
* 082ff78 Upgrade to Akka 2.4 (PR #124)
* e890679 Use Travis CI container infrastructure (PR #123)