### PR TITLE
Adapt Akka Future to Java 8 CompletableFuture

### DIFF
--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/compat/AkkaFutureAdapterTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/compat/AkkaFutureAdapterTest.scala
@@ -17,12 +17,17 @@ package com.comcast.xfinity.sirius.api.impl.compat
 
 import com.comcast.xfinity.sirius.NiceTest
 import org.scalatest.BeforeAndAfterAll
-import scala.concurrent.{ExecutionContext, Future => AkkaFuture}
-import akka.dispatch.ExecutionContexts._
+
+import scala.concurrent.{Await, Future}
 import akka.actor.ActorSystem
 import java.io.IOException
 import java.util.concurrent.{ExecutionException, TimeUnit, TimeoutException}
+import java.util.function.Consumer
+
 import akka.dispatch.ExecutionContexts
+import org.mockito.{Matchers, Mockito}
+
+import scala.concurrent.duration.Duration
 
 class AkkaFutureAdapterTest extends NiceTest with BeforeAndAfterAll {
 
@@ -30,38 +35,68 @@ class AkkaFutureAdapterTest extends NiceTest with BeforeAndAfterAll {
   implicit val ec = ExecutionContexts.global()
 
   override def afterAll {
-    as.shutdown()
-    as.awaitTermination()
+    Await.result(as.terminate(), Duration.Inf)
   }
 
   describe("AkkaFutureAdapter") {
     it("must throw an IllegalStateException when cancel is called") {
       intercept[IllegalStateException] {
-        val akkaFuture = AkkaFuture { "foo" }
+        val akkaFuture = Future { "foo" }
         new AkkaFutureAdapter[String](akkaFuture).cancel(true)
       }
     }
 
     it("must return the value expected on get") {
       assertResult("foo") {
-        val akkaFuture = AkkaFuture { "foo" }
+        val akkaFuture = Future { "foo" }
         new AkkaFutureAdapter[String](akkaFuture).get(2, TimeUnit.SECONDS)
       }
     }
 
     it("must throw a TimeoutException if it takes too long") {
       intercept[TimeoutException] {
-        val akkaFuture = AkkaFuture { Thread.sleep(1000); "foo" }
+        val akkaFuture = Future { Thread.sleep(1000); "foo" }
         new AkkaFutureAdapter[String](akkaFuture).get(500, TimeUnit.MILLISECONDS)
       }
     }
 
     it("must propogate an exception as an ExecutionException") {
       intercept[ExecutionException] {
-        val akkaFuture = AkkaFuture { throw new IOException("Boom") }
+        val akkaFuture = Future { throw new IOException("Boom") }
         new AkkaFutureAdapter[String](akkaFuture).get()
       }
     }
-  }
 
+    it("must complete the future with value") {
+      val akkaFuture = Future { "foo" }
+      val consumer = mock[Consumer[String]]
+      new AkkaFutureAdapter[String](akkaFuture).thenAccept(consumer)
+      Mockito.verify(consumer, Mockito.timeout(100).times(1))
+        .accept("foo")
+    }
+
+    it("must exceptionally complete the future with exception") {
+      assertResult("foo") {
+        val akkaFuture = Future {
+          throw new IOException("Boom")
+        }
+        val consumer = mock[Consumer[String]]
+        val function = mock[java.util.function.Function[Throwable, String]]
+        Mockito.doReturn("foo")
+          .when(function)
+          .apply(Matchers.any[Throwable])
+
+        val adapter = new AkkaFutureAdapter[String](akkaFuture)
+        adapter.thenAccept(consumer)
+        val continued = adapter.exceptionally(function)
+
+        Mockito.verify(function, Mockito.timeout(100).times(1))
+          .apply(Matchers.any[IOException])
+        Mockito.verify(consumer, Mockito.never())
+          .accept(Matchers.anyString)
+
+        continued.get
+      }
+    }
+  }
 }


### PR DESCRIPTION
This is a much simpler approach.  I've updated the `AkkaFutureAdapter` class to instead convert the Akka `Future[T]` to a Java 8 `CompletableFuture[T]`.

I've kept the `Sirius` interface the same as in that it continues to return `Future[T]` which would eliminate the potential for breaking a consumer which implements that interface directly, but that does put additional onus on the consumer to determine if the returned `Future[T]` is a `CompletableFuture[T]` or not. 