### PR TITLE
Use BufferedInputStream for read operations

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
@@ -189,6 +189,17 @@ object SiriusConfiguration {
   final val LOG_WRITE_CACHE_SIZE = "sirius.log.write-cache-size"
 
   /**
+    * Whether or not to use a buffered reader when reading through the log
+    */
+  final val LOG_USE_READ_BUFFER = "sirius.log.read-buffer-enabled"
+
+  /**
+    * Indicates the size of the buffer in bytes when reading events from the log.
+    * The default buffer size is 8192 bytes. (int)
+    */
+  final val LOG_READ_BUFFER_SIZE_BYTES = "sirius.log.read-buffer-size-bytes"
+
+  /**
    * Minutes between triggering compaction. First trigger will happen this many minutes
    * after boot.  A value of 0 turns off compaction, and compaction is off by default.
    */

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/SiriusFactory.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/SiriusFactory.scala
@@ -67,7 +67,7 @@ object SiriusFactory {
     val backendLog = {
       siriusConfig.getProp(SiriusConfiguration.LOG_VERSION_ID, "") match {
         case version if version == SegmentedUberStore.versionId => SegmentedUberStore(uberStoreDir, siriusConfig)
-        case _ => UberStore(uberStoreDir)
+        case _ => UberStore(uberStoreDir, siriusConfig)
       }
     }
 

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/state/StateSup.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/state/StateSup.scala
@@ -115,9 +115,8 @@ class StateSup(requestHandler: RequestHandler,
     val start = System.currentTimeMillis
 
     logger.info("Beginning SiriusLog replay at {}", start)
-    // TODO convert this to foreach
-    siriusLog.foldLeft(())(
-      (_, orderedEvent) =>
+    siriusLog.foreach(
+      orderedEvent =>
         try {
           orderedEvent.request match {
             case Put(key, body) => requestHandler.handlePut(key, body)

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberPair.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberPair.scala
@@ -16,11 +16,8 @@
 package com.comcast.xfinity.sirius.uberstore
 
 import com.comcast.xfinity.sirius.api.impl.OrderedEvent
-import com.comcast.xfinity.sirius.uberstore.seqindex.DiskOnlySeqIndex
-import com.comcast.xfinity.sirius.writeaheadlog.SiriusLog
-
-import data.UberDataFile
-import seqindex.SeqIndex
+import com.comcast.xfinity.sirius.uberstore.data.{UberDataFile, UberDataFileHandleFactory}
+import com.comcast.xfinity.sirius.uberstore.seqindex.{DiskOnlySeqIndex, SeqIndex}
 
 object UberPair {
 
@@ -33,9 +30,9 @@ object UberPair {
    *
    * @return an instantiated UberStoreFilePair
    */
-  def apply(baseDir: String, startingSeq: Long): UberPair = {
+  def apply(baseDir: String, startingSeq: Long, fileHandleFactory: UberDataFileHandleFactory): UberPair = {
     val baseName = "%s/%s".format(baseDir, startingSeq)
-    val dataFile = UberDataFile("%s.data".format(baseName))
+    val dataFile = UberDataFile("%s.data".format(baseName), fileHandleFactory)
     val index = DiskOnlySeqIndex("%s.index".format(baseName))
     repairIndex(index, dataFile)
     new UberPair(dataFile, index)

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberStore.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberStore.scala
@@ -17,8 +17,10 @@ package com.comcast.xfinity.sirius.uberstore
 
 import com.comcast.xfinity.sirius.api.impl.OrderedEvent
 import com.comcast.xfinity.sirius.writeaheadlog.SiriusLog
-import com.comcast.xfinity.sirius.uberstore.segmented.SegmentedUberStore
 import java.io.File
+
+import com.comcast.xfinity.sirius.api.SiriusConfiguration
+import com.comcast.xfinity.sirius.uberstore.data.UberDataFileHandleFactory
 
 object UberStore {
 
@@ -31,12 +33,14 @@ object UberStore {
    *
    * @return an instantiated UberStore
    */
-  def apply(baseDir: String): UberStore = {
+  def apply(baseDir: String, siriusConfig: SiriusConfiguration = new SiriusConfiguration): UberStore = {
     if (!isValidUberStore(baseDir)) {
       throw new IllegalStateException("Cannot start. Configured to boot with legacy UberStore, but other UberStore format found.")
     }
 
-    new UberStore(baseDir, UberPair(baseDir, 1L))
+    val fileHandleFactory = UberDataFileHandleFactory(siriusConfig)
+
+    new UberStore(baseDir, UberPair(baseDir, 1L, fileHandleFactory))
   }
 
   /**

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/BufferedFileReadHandle.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/BufferedFileReadHandle.scala
@@ -1,0 +1,125 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.comcast.xfinity.sirius.uberstore.data
+
+import java.io.{BufferedInputStream, DataInputStream, InputStream, RandomAccessFile}
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+
+import scala.annotation.tailrec
+
+object BufferedFileReadHandle {
+
+  /**
+    * Creates a new buffered sequential access [[UberDataFileReadHandle]] for the file
+    *
+    * @param dataFileName the name of the file
+    * @param baseOffset the initial offset
+    * @param readBufferSize the buffer size
+    */
+  def apply(dataFileName: String, baseOffset:Long, readBufferSize: Int): UberDataFileReadHandle = {
+    val randomAccessFile = new RandomAccessFile(dataFileName, "r")
+    randomAccessFile.seek(baseOffset)
+    val fileChannel = randomAccessFile.getChannel
+    val fileChannelInputStream = new FileChannelInputStream(fileChannel)
+    val inputStream = new BufferedInputStream(fileChannelInputStream, readBufferSize)
+    new BufferedFileReadHandle(inputStream, baseOffset)
+  }
+}
+
+/**
+  * Implementation of an Uberstore read file handle that uses buffered read operations
+  * @param inputStream the input stream containing the contents of the file
+  * @param baseOffset the offset from which read operations will start
+  */
+private[uberstore] class BufferedFileReadHandle(val inputStream: InputStream, val baseOffset: Long) extends UberDataFileReadHandle {
+  private val dataInputStream: DataInputStream = new DataInputStream(inputStream)
+  private var currentOffset: Long = baseOffset
+
+  /** @inheritdoc */
+  def offset(): Long = currentOffset
+
+  /** @inheritdoc */
+  override def eof(): Boolean = {
+    inputStream.mark(1)
+    try {
+      inputStream.read() == -1
+    } finally {
+      inputStream.reset()
+    }
+  }
+
+  /** @inheritdoc */
+  def readInt(): Int = {
+    val result = dataInputStream.readInt()
+    currentOffset += 4
+    result
+  }
+
+  /** @inheritdoc */
+  def readLong(): Long = {
+    val result = dataInputStream.readLong()
+    currentOffset += 8
+    result
+  }
+
+  /** @inheritdoc */
+  def readFully(array: Array[Byte]): Unit = {
+    dataInputStream.readFully(array)
+    currentOffset += array.length
+  }
+
+  /** @inheritdoc */
+  def close(): Unit = dataInputStream.close()
+}
+
+/**
+  * Helper class that wraps a [[java.nio.channels.FileChannel]] as an [[java.io.InputStream]] so that it can be
+  * used with [[java.io.BufferedInputStream]]
+  */
+private [uberstore] class FileChannelInputStream(private val channel: FileChannel) extends InputStream {
+  private val singleByteBuffer = ByteBuffer.allocate(1)
+
+  /**
+    * Reads the next byte from the channel if it is available, or returns -1.
+    * This method is required and here for completeness, but all calls from [[BufferedInputStream]]
+    * use [[java.io.InputStream#read(Array[Byte],Int,Int):Unit*]] so this method should never get called.
+    * @return the Int value of the Byte in the range of 0-255, or -1 if EOF
+    */
+  @tailrec
+  override final def read(): Int = {
+    singleByteBuffer.reset()
+    channel.read(singleByteBuffer) match {
+      case -1 => -1
+      case 0 => read()
+      case _ =>
+        singleByteBuffer.flip()
+        singleByteBuffer.get()
+    }
+  }
+
+  override def read(b: Array[Byte]): Int = channel.read(ByteBuffer.wrap(b))
+
+  override def read(b: Array[Byte], off: Int, len: Int): Int = channel.read(ByteBuffer.wrap(b, off, len))
+
+  override def skip(n: Long): Long = {
+    val newPosition = channel.position() + n
+    channel.position(newPosition)
+    newPosition
+  }
+
+  override def close(): Unit = channel.close()
+}

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/BufferedReadFileHandleFactory.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/BufferedReadFileHandleFactory.scala
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.comcast.xfinity.sirius.uberstore.data
+
+/**
+  * An Uberstore data file handle factory that creates read file handles that use buffered read operations
+  * @param readBufferSize the size of the buffer for read operations
+  */
+private [uberstore] class BufferedReadFileHandleFactory(readBufferSize: Int) extends UberDataFileHandleFactory {
+
+  /** @inheritdoc */
+  override def createWriteHandle(dataFileName: String) = RandomAccessFileWriteHandle(dataFileName)
+
+  /**
+    * Creates a file handle for reading from an Uberstore data file using buffered operations
+    * @param dataFileName the absolute path to the Uberstore data file
+    * @param baseOffset the offset within the Uberstore data file at which read operations will begin
+    * @return the file handle
+    */
+  override def createReadHandle(dataFileName: String, baseOffset: Long) = BufferedFileReadHandle(dataFileName, baseOffset, readBufferSize)
+}

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/RandomAccessFileHandleFactory.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/RandomAccessFileHandleFactory.scala
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.comcast.xfinity.sirius.uberstore.data
+
+/**
+  * An Uberstore data file handle factory that creates random access file handles
+  */
+private [uberstore] case object RandomAccessFileHandleFactory extends UberDataFileHandleFactory {
+  /** @inheritdoc */
+  override def createWriteHandle(dataFileName: String) = RandomAccessFileWriteHandle(dataFileName)
+  /** @inheritdoc */
+  override def createReadHandle(dataFileName: String, baseOffset: Long) = RandomAccessFileReadHandle(dataFileName, baseOffset)
+}

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/RandomAccessFileReadHandle.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/RandomAccessFileReadHandle.scala
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.comcast.xfinity.sirius.uberstore.data
+
+import java.io.RandomAccessFile
+
+object RandomAccessFileReadHandle {
+
+  /**
+    * Creates a new random access [[UberDataFileReadHandle]] for the file
+    *
+    * @param dataFileName the name of the file
+    * @param baseOffset the initial offset
+    */
+  def apply(dataFileName: String, baseOffset: Long): UberDataFileReadHandle = {
+    val randomAccessFile = new RandomAccessFile(dataFileName, "r")
+    randomAccessFile.seek(baseOffset)
+    new RandomAccessFileReadHandle(randomAccessFile)
+  }
+}
+
+/**
+  * Implementation of an Uberstore read file handle that uses random access file operations
+  */
+private[uberstore] class RandomAccessFileReadHandle(private val randomAccessFile: RandomAccessFile) extends UberDataFileReadHandle {
+  /** @inheritdoc */
+  override def offset(): Long = randomAccessFile.getFilePointer
+  /** @inheritdoc */
+  override def eof(): Boolean = randomAccessFile.getFilePointer >= randomAccessFile.length()
+  /** @inheritdoc */
+  override def readInt(): Int = randomAccessFile.readInt()
+  /** @inheritdoc */
+  override def readLong(): Long = randomAccessFile.readLong()
+  /** @inheritdoc */
+  override def readFully(array: Array[Byte]): Unit = randomAccessFile.readFully(array)
+  /** @inheritdoc */
+  override def close(): Unit = randomAccessFile.close()
+}

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/RandomAccessFileWriteHandle.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/RandomAccessFileWriteHandle.scala
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.comcast.xfinity.sirius.uberstore.data
+
+import java.io.RandomAccessFile
+
+object RandomAccessFileWriteHandle {
+
+  /**
+    * Creates an Uberstore data file write handle that uses random access write operations
+    * @param dataFileName the absolute path to the Uberstore data file
+    * @return the file handle
+    */
+  def apply(dataFileName: String): UberDataFileWriteHandle = {
+    val randomAccessFile = new RandomAccessFile(dataFileName, "rw")
+    randomAccessFile.seek(randomAccessFile.length())
+    new RandomAccessFileWriteHandle(randomAccessFile)
+  }
+}
+
+/**
+  * Implementation of an Uberstore write file handle that uses random access write operations
+  */
+private [data] class RandomAccessFileWriteHandle(randomAccessFile: RandomAccessFile) extends UberDataFileWriteHandle {
+
+  /** @inheritdoc */
+  override def offset(): Long = randomAccessFile.getFilePointer
+
+  /** @inheritdoc */
+  override def write(bytes: Array[Byte]): Long = {
+    val offset = randomAccessFile.getFilePointer
+    randomAccessFile.write(bytes)
+    offset
+  }
+
+  /** @inheritdoc */
+  override def close(): Unit = randomAccessFile.close()
+}

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/UberDataFileHandleFactory.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/UberDataFileHandleFactory.scala
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.comcast.xfinity.sirius.uberstore.data
+
+import com.comcast.xfinity.sirius.api.SiriusConfiguration
+
+object UberDataFileHandleFactory {
+
+  /**
+    * Creates a [[UberDataFileHandleFactory]] that can create Uberstore data file handles based on the configuration
+    * @param siriusConfig the Sirius configuration
+    * @return the factory for creating file handles
+    */
+  def apply(siriusConfig: SiriusConfiguration): UberDataFileHandleFactory = {
+    val LOG_USE_READ_BUFFER = siriusConfig.getProp(SiriusConfiguration.LOG_USE_READ_BUFFER, false)
+    val LOG_READ_BUFFER_SIZE = siriusConfig.getProp(SiriusConfiguration.LOG_READ_BUFFER_SIZE_BYTES, 8 * 1024)
+
+    apply(LOG_USE_READ_BUFFER, LOG_READ_BUFFER_SIZE)
+  }
+
+  /**
+    * Creates an [[UberDataFileHandleFactory]] that can create Uberstore data file handles based on specific configuration values
+    * @param useReadBuffer `true` to use buffered read operations
+    * @param readBufferSize the size of the read buffer when using buffered read operations
+    * @return the factory for creating file handles
+    */
+  def apply(useReadBuffer: Boolean, readBufferSize: Int): UberDataFileHandleFactory = {
+    if (useReadBuffer && readBufferSize > 0) {
+      new BufferedReadFileHandleFactory(readBufferSize)
+    } else {
+      RandomAccessFileHandleFactory
+    }
+  }
+}
+
+/**
+  * Trait providing abstraction to obtaining file handles for read and write operations to an Uberstore data file
+  */
+trait UberDataFileHandleFactory {
+
+  /**
+    * Creates a file handle for writing to an Uberstore data file
+    * @param dataFileName the absolute path to the Uberstore data file
+    * @return the file handle
+    */
+  def createWriteHandle(dataFileName: String): UberDataFileWriteHandle
+
+  /**
+    * Creates a file handle for reading from an Uberstore data file
+    * @param dataFileName the absolute path to the Uberstore data file
+    * @param baseOffset the offset within the Uberstore data file at which read operations will begin
+    * @return the file handle
+    */
+  def createReadHandle(dataFileName: String, baseOffset: Long): UberDataFileReadHandle
+}

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/UberDataFileReadHandle.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/UberDataFileReadHandle.scala
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.comcast.xfinity.sirius.uberstore.data
+
+import java.io.EOFException
+
+/**
+  * Trait providing abstraction of low level read operations to an Uberstore
+  */
+trait UberDataFileReadHandle extends AutoCloseable {
+  /**
+    * Returns the current offset within the file
+    * @return the offset
+    */
+  def offset(): Long
+
+  /**
+    * Returns whether the reader is at the end of the file
+    * @return `true` if at the end of the file; otherwise, `false`
+    */
+  def eof(): Boolean
+
+  /**
+    * Reads the next 32-bit Integer from the file
+    * @return the 32-bit Integer
+    * @throws EOFException if EOF
+    */
+  def readInt(): Int
+
+  /**
+    * Reads the next 64-bit Long from the file
+    * @return the 64-bit Long
+    * @throws EOFException if EOF
+    */
+  def readLong(): Long
+
+  /**
+    * Populates the entire array with the next bytes from the file
+    * @param array to populate
+    * @throws EOFException if EOF
+    */
+  def readFully(array: Array[Byte]): Unit
+}

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/UberDataFileWriteHandle.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/UberDataFileWriteHandle.scala
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.comcast.xfinity.sirius.uberstore.data
+
+/**
+  * Trait providing abstraction of low level write operations to an Uberstore
+  */
+trait UberDataFileWriteHandle extends AutoCloseable {
+  /**
+    * Returns the current offset within the file
+    * @return the offset
+    */
+  def offset(): Long
+
+  /**
+    * Writes the array of bytes to the file
+    * @param bytes to write
+    * @return the offset within the file at which the bytes were written
+    */
+  def write(bytes: Array[Byte]): Long
+}

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/UberStoreFileOps.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/UberStoreFileOps.scala
@@ -15,7 +15,7 @@
  */
 package com.comcast.xfinity.sirius.uberstore.data
 
-import java.io.RandomAccessFile
+import java.io.{DataInputStream, RandomAccessFile}
 
 /**
  * Trait providing low level File operations for an UberStore
@@ -34,7 +34,7 @@ trait UberStoreFileOps {
    *
    * @return offset this object was stored at
    */
-  def put(writeHandle: RandomAccessFile, body: Array[Byte]): Long
+  def put(writeHandle: UberDataFileWriteHandle, body: Array[Byte]): Long
 
   /**
    * Read the next entry out of the file, from the current offset
@@ -47,5 +47,5 @@ trait UberStoreFileOps {
    *
    * @return Some(bytes) or None if EOF encountered
    */
-  def readNext(readHandle: RandomAccessFile): Option[Array[Byte]]
+  def readNext(readHandle: UberDataFileReadHandle): Option[Array[Byte]]
 }

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/Segment.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/Segment.scala
@@ -16,8 +16,8 @@
 package com.comcast.xfinity.sirius.uberstore.segmented
 
 import com.comcast.xfinity.sirius.api.impl.OrderedEvent
-import com.comcast.xfinity.sirius.uberstore.seqindex.{SeqIndex, DiskOnlySeqIndex}
-import com.comcast.xfinity.sirius.uberstore.data.UberDataFile
+import com.comcast.xfinity.sirius.uberstore.seqindex.{DiskOnlySeqIndex, SeqIndex}
+import com.comcast.xfinity.sirius.uberstore.data.{UberDataFile, UberDataFileHandleFactory}
 import java.io.File
 
 object Segment {
@@ -30,8 +30,8 @@ object Segment {
    *
    * @return an Segment instance, fully repaired and usable
    */
-  def apply(base: File, name: String): Segment = {
-    apply(new File(base, name))
+  def apply(base: File, name: String, fileHandleFactory: UberDataFileHandleFactory): Segment = {
+    apply(new File(base, name), fileHandleFactory)
   }
 
   /**
@@ -42,7 +42,7 @@ object Segment {
    *
    * @return an Segment instance, fully repaired and usable
    */
-  def apply(location: File): Segment = {
+  def apply(location: File, fileHandleFactory: UberDataFileHandleFactory): Segment = {
     location.mkdirs()
 
     val dataFile = new File(location, "data")
@@ -50,7 +50,7 @@ object Segment {
     val compactionFlagFile = new File(location, "keys-collected")
     val internalCompactionFlagFile = new File(location, "internally-compacted")
 
-    val data = UberDataFile(dataFile.getAbsolutePath)
+    val data = UberDataFile(dataFile.getAbsolutePath, fileHandleFactory)
     val index = DiskOnlySeqIndex(indexFile.getAbsolutePath)
     val compactionFlag = FlagFile(compactionFlagFile.getAbsolutePath)
     val internalCompactionFlag = FlagFile(internalCompactionFlagFile.getAbsolutePath)
@@ -96,8 +96,12 @@ object Segment {
  * @param dataFile the UberDataFile to store data in
  * @param index the SeqIndex to use
  */
-class Segment private[uberstore](val location: File, val name: String, dataFile: UberDataFile,
-                                 index: SeqIndex, compactionFlag: FlagFile, internalCompactionFlag: FlagFile) {
+class Segment private[uberstore](val location: File,
+                                 val name: String,
+                                 dataFile: UberDataFile,
+                                 index: SeqIndex,
+                                 compactionFlag: FlagFile,
+                                 internalCompactionFlag: FlagFile) {
 
   /**
    * Get the number of entries written to the Segment

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/BufferedFileReadHandleTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/BufferedFileReadHandleTest.scala
@@ -1,0 +1,160 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.comcast.xfinity.sirius.uberstore.data
+
+import java.io.{EOFException, InputStream, OutputStream, RandomAccessFile}
+import java.nio.ByteBuffer
+import java.nio.file.{Files, Path, StandardOpenOption}
+
+import com.comcast.xfinity.sirius.NiceTest
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfter
+
+import scala.util.Random
+
+class BufferedFileReadHandleTest extends UberDataFileHandleTest {
+
+  val readBufferSize: Int = 8 * 1024
+
+  describe("eof") {
+    it("returns false when read returns a valid unsigned byte") {
+      val inputStream = mock[InputStream]
+      val expected = Random.nextInt(256)
+      doReturn(expected).when(inputStream).read()
+
+      val underTest = new BufferedFileReadHandle(inputStream, 0L)
+      val result = underTest.eof()
+      assert(!result)
+
+      verify(inputStream).mark(1)
+      verify(inputStream).reset()
+    }
+    it("returns true when read returns -1") {
+      val inputStream = mock[InputStream]
+      val expected = -1
+      doReturn(expected).when(inputStream).read()
+
+      val underTest = new BufferedFileReadHandle(inputStream, 0L)
+      val result = underTest.eof()
+      assert(result)
+
+      verify(inputStream).mark(1)
+      verify(inputStream).reset()
+    }
+  }
+  describe("readInt") {
+    it("returns 32-bit Integer and advances offset") {
+      val expected = Random.nextInt()
+      writeInts(expected)
+
+      val underTest = BufferedFileReadHandle(tempPath.toString, 0L, readBufferSize)
+      val result = underTest.readInt()
+      assert(result == expected)
+      assert(underTest.offset() == 4)
+    }
+    it("reads 32-bit Integer at offset and advances offset") {
+      val expected = Random.nextInt()
+      val baseOffset = Random.nextInt(500)
+      writeRandomBytes(baseOffset)
+      writeInts(expected)
+
+      val underTest = BufferedFileReadHandle(tempPath.toString, baseOffset, readBufferSize)
+      val result = underTest.readInt()
+      assert(result == expected)
+      assert(underTest.offset() == baseOffset + 4)
+    }
+    it("throws EOFException when EOF") {
+      val underTest = BufferedFileReadHandle(tempPath.toString, 0L, readBufferSize)
+      intercept[EOFException] {
+        val _ = underTest.readInt()
+      }
+    }
+  }
+  describe("readLong") {
+    it("returns 64-bit Integer and advances offset") {
+      val expected = Random.nextLong()
+      writeLongs(expected)
+      val underTest = BufferedFileReadHandle(tempPath.toString, 0L, readBufferSize)
+      val result = underTest.readLong()
+      assert(result == expected)
+      assert(underTest.offset() == 8)
+    }
+    it("returns 64-bit Integer at offset and advances offset") {
+      val baseOffset = Random.nextInt(500)
+      val expected = Random.nextLong()
+      writeRandomBytes(baseOffset)
+      writeLongs(expected)
+
+      val underTest = BufferedFileReadHandle(tempPath.toString, baseOffset, readBufferSize)
+      val result = underTest.readLong()
+      assert(result == expected)
+      assert(underTest.offset() == baseOffset + 8)
+    }
+    it("throws EOFException when EOF") {
+      val underTest = BufferedFileReadHandle(tempPath.toString, 0L, readBufferSize)
+      intercept[EOFException] {
+        val _ = underTest.readLong()
+      }
+    }
+  }
+  describe("readFully") {
+    it("fills array and advances offset") {
+      val expected = randomBytes(10)
+      writeBytes(expected: _*)
+      val underTest = BufferedFileReadHandle(tempPath.toString, 0L, readBufferSize)
+      val array = new Array[Byte](10)
+      underTest.readFully(array)
+      assert(array.sameElements(expected))
+      assert(underTest.offset() == 10)
+    }
+    it("fills array at offset and advances offset") {
+      val baseOffset = Random.nextInt(500)
+      val expected = randomBytes(10)
+      writeRandomBytes(baseOffset)
+      writeBytes(expected: _*)
+      val underTest = BufferedFileReadHandle(tempPath.toString, baseOffset, readBufferSize)
+      val array = new Array[Byte](10)
+      underTest.readFully(array)
+      assert(array.sameElements(expected))
+      assert(underTest.offset() == baseOffset + 10)
+    }
+    it("throws EOFException when EOF") {
+      val underTest = BufferedFileReadHandle(tempPath.toString, 0L, readBufferSize)
+      intercept[EOFException] {
+        val array = new Array[Byte](10)
+        underTest.readFully(array)
+      }
+    }
+    it("throws EOFException when less than required bytes remaining") {
+      writeRandomBytes(7)
+      val underTest = BufferedFileReadHandle(tempPath.toString, 0L, readBufferSize)
+      intercept[EOFException] {
+        val array = new Array[Byte](10)
+        underTest.readFully(array)
+      }
+    }
+  }
+  describe("close") {
+    it("closes the underlying InputStream") {
+      val mockInputStream = mock[InputStream]
+      val underTest = new BufferedFileReadHandle(mockInputStream, 0L)
+      underTest.close()
+
+      verify(mockInputStream).close()
+    }
+  }
+}

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/BufferedReadFileHandleFactoryTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/BufferedReadFileHandleFactoryTest.scala
@@ -1,0 +1,63 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.comcast.xfinity.sirius.uberstore.data
+
+class BufferedReadFileHandleFactoryTest extends UberDataFileHandleTest {
+  describe("createWriteHandle") {
+    it("creates a random access write handle to the file") {
+      writeRandomBytes(256)
+
+      val underTest = new BufferedReadFileHandleFactory(256)
+      val result = underTest.createWriteHandle(tempPath.toString)
+
+      try {
+        assert(result.isInstanceOf[RandomAccessFileWriteHandle])
+        assert(result.offset() == 256L)
+      } finally {
+        result.close()
+      }
+    }
+  }
+  describe("createReadHandle") {
+    it("creates a buffered read handle to the file") {
+      writeRandomBytes(256)
+
+      val underTest = new BufferedReadFileHandleFactory(256)
+      val result = underTest.createReadHandle(tempPath.toString, 0L)
+
+      try {
+        assert(result.isInstanceOf[BufferedFileReadHandle])
+        assert(result.offset() == 0L)
+      } finally {
+        result.close()
+      }
+    }
+    it("creates a buffered read handle to the file at the specified offset") {
+      writeRandomBytes(256)
+
+      val underTest = new BufferedReadFileHandleFactory(256)
+      val result = underTest.createReadHandle(tempPath.toString, 100L)
+
+      try {
+        assert(result.isInstanceOf[BufferedFileReadHandle])
+        assert(result.offset() == 100L)
+      } finally {
+        result.close()
+      }
+    }
+  }
+}

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/RandomAccessFileHandleFactoryTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/RandomAccessFileHandleFactoryTest.scala
@@ -1,0 +1,63 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.comcast.xfinity.sirius.uberstore.data
+
+class RandomAccessFileHandleFactoryTest extends UberDataFileHandleTest {
+  describe("createWriteHandle") {
+    it("creates a random access write handle to the file") {
+      writeRandomBytes(256)
+
+      val underTest = RandomAccessFileHandleFactory
+      val result = underTest.createWriteHandle(tempPath.toString)
+
+      try {
+        assert(result.isInstanceOf[RandomAccessFileWriteHandle])
+        assert(result.offset() == 256L)
+      } finally {
+        result.close()
+      }
+    }
+  }
+  describe("createReadHandle") {
+    it("creates a random access read handle to the file") {
+      writeRandomBytes(256)
+
+      val underTest = RandomAccessFileHandleFactory
+      val result = underTest.createReadHandle(tempPath.toString, 0L)
+
+      try {
+        assert(result.isInstanceOf[RandomAccessFileReadHandle])
+        assert(result.offset() == 0L)
+      } finally {
+        result.close()
+      }
+    }
+    it("creates a random access read handle to the file at the specified offset") {
+      writeRandomBytes(256)
+
+      val underTest = RandomAccessFileHandleFactory
+      val result = underTest.createReadHandle(tempPath.toString, 100L)
+
+      try {
+        assert(result.isInstanceOf[RandomAccessFileReadHandle])
+        assert(result.offset() == 100L)
+      } finally {
+        result.close()
+      }
+    }
+  }
+}

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/RandomAccessFileReadHandleTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/RandomAccessFileReadHandleTest.scala
@@ -1,0 +1,152 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.comcast.xfinity.sirius.uberstore.data
+
+import java.io.{EOFException, InputStream, OutputStream, RandomAccessFile}
+import java.nio.ByteBuffer
+import java.nio.file.{Files, Path, StandardOpenOption}
+
+import com.comcast.xfinity.sirius.NiceTest
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfter
+
+import scala.util.Random
+
+class RandomAccessFileReadHandleTest extends UberDataFileHandleTest {
+
+  describe("eof") {
+    it("returns false when getFilePointer is less than length") {
+      val mockRandomAccessFile = mock[RandomAccessFile]
+      doReturn(10L).when(mockRandomAccessFile).getFilePointer
+      doReturn(20L).when(mockRandomAccessFile).length()
+
+      val underTest = new RandomAccessFileReadHandle(mockRandomAccessFile)
+      val result = underTest.eof()
+      assert(!result)
+    }
+    it("returns true when at end of file") {
+      val mockRandomAccessFile = mock[RandomAccessFile]
+      doReturn(20L).when(mockRandomAccessFile).getFilePointer
+      doReturn(20L).when(mockRandomAccessFile).length()
+
+      val underTest = new RandomAccessFileReadHandle(mockRandomAccessFile)
+      val result = underTest.eof()
+      assert(result)
+    }
+  }
+  describe("readInt") {
+    it("returns 32-bit Integer and advances offset") {
+      val expected = Random.nextInt()
+      writeInts(expected)
+
+      val underTest = RandomAccessFileReadHandle(tempPath.toString, 0L)
+      val result = underTest.readInt()
+      assert(result == expected)
+      assert(underTest.offset() == 4)
+    }
+    it("reads 32-bit Integer at offset and advances offset") {
+      val expected = Random.nextInt()
+      val baseOffset = Random.nextInt(500)
+      writeRandomBytes(baseOffset)
+      writeInts(expected)
+
+      val underTest = RandomAccessFileReadHandle(tempPath.toString, baseOffset)
+      val result = underTest.readInt()
+      assert(result == expected)
+      assert(underTest.offset() == baseOffset + 4)
+    }
+    it("throws EOFException when EOF") {
+      val underTest = RandomAccessFileReadHandle(tempPath.toString, 0L)
+      intercept[EOFException] {
+        val _ = underTest.readInt()
+      }
+    }
+  }
+  describe("readLong") {
+    it("returns 64-bit Integer and advances offset") {
+      val expected = Random.nextLong()
+      writeLongs(expected)
+      val underTest = RandomAccessFileReadHandle(tempPath.toString, 0L)
+      val result = underTest.readLong()
+      assert(result == expected)
+      assert(underTest.offset() == 8)
+    }
+    it("returns 64-bit Integer at offset and advances offset") {
+      val baseOffset = Random.nextInt(500)
+      val expected = Random.nextLong()
+      writeRandomBytes(baseOffset)
+      writeLongs(expected)
+
+      val underTest = RandomAccessFileReadHandle(tempPath.toString, baseOffset)
+      val result = underTest.readLong()
+      assert(result == expected)
+      assert(underTest.offset() == baseOffset + 8)
+    }
+    it("throws EOFException when EOF") {
+      val underTest = RandomAccessFileReadHandle(tempPath.toString, 0L)
+      intercept[EOFException] {
+        val _ = underTest.readLong()
+      }
+    }
+  }
+  describe("readFully") {
+    it("fills array and advances offset") {
+      val expected = randomBytes(10)
+      writeBytes(expected: _*)
+      val underTest = RandomAccessFileReadHandle(tempPath.toString, 0L)
+      val array = new Array[Byte](10)
+      underTest.readFully(array)
+      assert(array.sameElements(expected))
+      assert(underTest.offset() == 10)
+    }
+    it("fills array at offset and advances offset") {
+      val baseOffset = Random.nextInt(500)
+      val expected = randomBytes(10)
+      writeRandomBytes(baseOffset)
+      writeBytes(expected: _*)
+      val underTest = RandomAccessFileReadHandle(tempPath.toString, baseOffset)
+      val array = new Array[Byte](10)
+      underTest.readFully(array)
+      assert(array.sameElements(expected))
+      assert(underTest.offset() == baseOffset + 10)
+    }
+    it("throws EOFException when EOF") {
+      val underTest = RandomAccessFileReadHandle(tempPath.toString, 0L)
+      intercept[EOFException] {
+        val array = new Array[Byte](10)
+        underTest.readFully(array)
+      }
+    }
+    it("throws EOFException when less than required bytes remaining") {
+      writeRandomBytes(7)
+      val underTest = RandomAccessFileReadHandle(tempPath.toString, 0L)
+      intercept[EOFException] {
+        val array = new Array[Byte](10)
+        underTest.readFully(array)
+      }
+    }
+  }
+  describe("close") {
+    it("closes the underlying RandomAccessFile") {
+      val mockRandomAccessFile = mock[RandomAccessFile]
+      val underTest = new RandomAccessFileReadHandle(mockRandomAccessFile)
+      underTest.close()
+
+      verify(mockRandomAccessFile).close()
+    }
+  }
+}

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/RandomAccessFileWriteHandleTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/RandomAccessFileWriteHandleTest.scala
@@ -1,0 +1,86 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.comcast.xfinity.sirius.uberstore.data
+
+import java.io.RandomAccessFile
+
+import org.mockito.Mockito._
+
+import scala.util.Random
+
+class RandomAccessFileWriteHandleTest extends UberDataFileHandleTest {
+
+  describe("apply") {
+    it("seeks to the end of the file") {
+      writeRandomBytes(50)
+      val underTest = RandomAccessFileWriteHandle(tempPath.toString)
+      try {
+       assert(underTest.offset() == 50L)
+      } finally {
+        underTest.close()
+      }
+    }
+  }
+  describe("write") {
+    it("writes to the underlying file") {
+      val expected = new Array[Byte](50)
+      Random.nextBytes(expected)
+
+      val underTest = RandomAccessFileWriteHandle(tempPath.toString)
+      try {
+        underTest.write(expected)
+      } finally {
+        underTest.close()
+      }
+
+      val result = readBytes()
+      assert(result sameElements expected)
+    }
+  }
+  describe("offset") {
+    it("returns the current filePointer") {
+      val randomAccessFile = mock[RandomAccessFile]
+      doReturn(1000L).when(randomAccessFile).getFilePointer
+
+      val underTest = new RandomAccessFileWriteHandle(randomAccessFile)
+      assert(underTest.offset() == 1000L)
+    }
+    it("returns the filePointer prior to writing the bytes") {
+      val randomAccessFile = mock[RandomAccessFile]
+      doReturn(1000L).when(randomAccessFile).getFilePointer
+
+      val underTest = new RandomAccessFileWriteHandle(randomAccessFile)
+      val bytes = new Array[Byte](50)
+      Random.nextBytes(bytes)
+      val result = underTest.write(bytes)
+
+      assert(result == 1000L)
+      val order = inOrder(randomAccessFile)
+      order.verify(randomAccessFile).getFilePointer
+      order.verify(randomAccessFile).write(bytes)
+    }
+  }
+  describe("close") {
+    it("calls close on the underlying RandomAccessFile") {
+      val randomAccessFile = mock[RandomAccessFile]
+
+      val underTest = new RandomAccessFileWriteHandle(randomAccessFile)
+      underTest.close()
+      verify(randomAccessFile).close()
+    }
+  }
+}

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/UberDataFileHandleFactoryTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/UberDataFileHandleFactoryTest.scala
@@ -1,0 +1,62 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.comcast.xfinity.sirius.uberstore.data
+
+import com.comcast.xfinity.sirius.NiceTest
+import com.comcast.xfinity.sirius.api.SiriusConfiguration
+
+class UberDataFileHandleFactoryTest extends NiceTest {
+
+  describe("apply") {
+    it("returns RandomAccessFileHandleFactory when LOG_USE_READ_BUFFER is false") {
+      val siriusConfig = new SiriusConfiguration
+      siriusConfig.setProp(SiriusConfiguration.LOG_USE_READ_BUFFER, false)
+
+      val fileHandleFactory = UberDataFileHandleFactory(siriusConfig)
+      assert(fileHandleFactory == RandomAccessFileHandleFactory)
+    }
+    it("returns RandomAccessFileHandleFactory when LOG_USE_READ_BUFFER is not set") {
+      val siriusConfig = new SiriusConfiguration
+
+      val fileHandleFactory = UberDataFileHandleFactory(siriusConfig)
+      assert(fileHandleFactory == RandomAccessFileHandleFactory)
+    }
+    it("returns RandomAccessFileHandleFactory when LOG_USE_READ_BUFFER is true and LOG_READ_BUFFER_SIZE_BYTES is zero") {
+      val siriusConfig = new SiriusConfiguration
+      siriusConfig.setProp(SiriusConfiguration.LOG_USE_READ_BUFFER, true)
+      siriusConfig.setProp(SiriusConfiguration.LOG_READ_BUFFER_SIZE_BYTES, 0)
+
+      val fileHandleFactory = UberDataFileHandleFactory(siriusConfig)
+      assert(fileHandleFactory == RandomAccessFileHandleFactory)
+    }
+    it("returns BufferedReadFileHandleFactory when LOG_USE_READ_BUFFER is true and LOG_READ_BUFFER_SIZE_BYTES is greater than zero") {
+      val siriusConfig = new SiriusConfiguration
+      siriusConfig.setProp(SiriusConfiguration.LOG_USE_READ_BUFFER, true)
+      siriusConfig.setProp(SiriusConfiguration.LOG_READ_BUFFER_SIZE_BYTES, 1)
+
+      val fileHandleFactory = UberDataFileHandleFactory(siriusConfig)
+      assert(fileHandleFactory.isInstanceOf[BufferedReadFileHandleFactory])
+    }
+    it("returns BufferedReadFileHandleFactory when LOG_USE_READ_BUFFER is true and LOG_READ_BUFFER_SIZE_BYTES is not set") {
+      val siriusConfig = new SiriusConfiguration
+      siriusConfig.setProp(SiriusConfiguration.LOG_USE_READ_BUFFER, true)
+
+      val fileHandleFactory = UberDataFileHandleFactory(siriusConfig)
+      assert(fileHandleFactory.isInstanceOf[BufferedReadFileHandleFactory])
+    }
+  }
+}

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/UberDataFileHandleTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/data/UberDataFileHandleTest.scala
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2012-2019 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.comcast.xfinity.sirius.uberstore.data
+
+import java.io.OutputStream
+import java.nio.ByteBuffer
+import java.nio.file.{Files, Path, StandardOpenOption}
+
+import com.comcast.xfinity.sirius.NiceTest
+import org.scalatest.BeforeAndAfter
+
+import scala.util.Random
+
+trait UberDataFileHandleTest extends NiceTest with BeforeAndAfter {
+
+  var tempPath: Path = _
+
+  before {
+    tempPath = Files.createTempFile(getClass.getSimpleName, "test")
+  }
+  after {
+    Files.delete(tempPath)
+  }
+
+  def write(f: OutputStream => Unit): Unit = {
+    val outputStream = Files.newOutputStream(tempPath, StandardOpenOption.APPEND)
+    try {
+      f(outputStream)
+    } finally {
+      outputStream.close()
+    }
+  }
+
+  def randomBytes(len: Int): Seq[Byte] = {
+    val array = new Array[Byte](len)
+    Random.nextBytes(array)
+    array.toSeq
+  }
+
+  def writeRandomBytes(len: Int): Unit = writeBytes(randomBytes(len):_*)
+
+  def writeBytes(bytes: Byte*): Unit = write { outputStream =>
+    outputStream.write(bytes.toArray)
+  }
+
+  def writeInts(ints: Int*): Unit = write { outputStream =>
+    val buffer = ByteBuffer.allocate(ints.length * 4)
+    buffer.asIntBuffer().put(ints.toArray)
+    outputStream.write(buffer.array())
+  }
+
+  def writeLongs(longs: Long*): Unit = write { outputStream =>
+    val buffer = ByteBuffer.allocate(longs.length * 8)
+    buffer.asLongBuffer().put(longs.toArray)
+    outputStream.write(buffer.array())
+  }
+
+  def readBytes(): Array[Byte] = Files.readAllBytes(tempPath)
+}

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentTest.scala
@@ -19,7 +19,7 @@ package com.comcast.xfinity.sirius.uberstore.segmented
 import com.comcast.xfinity.sirius.NiceTest
 import org.mockito.Mockito._
 import org.mockito.Matchers.{any, anyLong, eq => meq}
-import com.comcast.xfinity.sirius.uberstore.data.UberDataFile
+import com.comcast.xfinity.sirius.uberstore.data.{RandomAccessFileHandleFactory, UberDataFile, UberDataFileHandleFactory}
 import com.comcast.xfinity.sirius.uberstore.seqindex.SeqIndex
 import java.io.{File => JFile}
 
@@ -56,6 +56,11 @@ class SegmentTest extends NiceTest with BeforeAndAfterAll {
     dir.mkdirs()
     dir
   }
+
+  val fileHandleFactory: UberDataFileHandleFactory = RandomAccessFileHandleFactory
+
+  def buildSegment(base: JFile, name: String) =
+    Segment(base, name, fileHandleFactory)
 
   override def afterAll() {
     File(tempDir.getPath).delete()
@@ -154,25 +159,25 @@ class SegmentTest extends NiceTest with BeforeAndAfterAll {
   describe ("keys"){
 
     it ("Should return an empty set if the set of keys are empty"){
-      val underTest = Segment(tempDir, "0keys")
+      val underTest = buildSegment(tempDir, "0keys")
       assert(underTest.keys.isEmpty)
     }
 
     it ("Should return the correct number of keys if the set of keys is not empty. With Deletes only"){
-      val underTest = Segment(tempDir, "hasKeys-Delete")
+      val underTest = buildSegment(tempDir, "hasKeys-Delete")
       underTest.writeEntry(OrderedEvent(1, 678, Delete("yarr")))
       underTest.writeEntry(OrderedEvent(2, 1200, Delete("secondYarr")))
       assert(2 === underTest.keys.size)
     }
     it ("Should return the correct number of keys if the set of keys is not empty. With Puts only"){
-      val underTest = Segment(tempDir, "hasKeys-Put")
+      val underTest = buildSegment(tempDir, "hasKeys-Put")
       val newByteArray = new StringOps("data").getBytes
       underTest.writeEntry(OrderedEvent(1, 678, Put("yarr",newByteArray)))
       underTest.writeEntry(OrderedEvent(2, 1000, Put("secondYarr",newByteArray)))
       assert(Set("yarr", "secondYarr") === underTest.keys)
     }
     it ("Should return the correct number of keys if the set of keys is not empty. With Puts & Deletes"){
-      val underTest = Segment(tempDir, "hasKeys-All")
+      val underTest = buildSegment(tempDir, "hasKeys-All")
       val newByteArray = new StringOps("data").getBytes
       underTest.writeEntry(OrderedEvent(1, 678, Put("yarr",newByteArray)))
       underTest.writeEntry(OrderedEvent(2, 1000, Put("secondYarr",newByteArray)))
@@ -181,7 +186,7 @@ class SegmentTest extends NiceTest with BeforeAndAfterAll {
       assert(Set("yarr", "secondYarr", "thirdYarr", "fourthYarr") === underTest.keys)
     }
     it ("should return a unique number of keys if the set of keys is not empty and has duplicates"){
-      val underTest = Segment(tempDir, "hasUniqueKeys")
+      val underTest = buildSegment(tempDir, "hasUniqueKeys")
       val newByteArray = new StringOps("data").getBytes
       underTest.writeEntry(OrderedEvent(1, 678, Delete("yarr")))
       underTest.writeEntry(OrderedEvent(2, 1200, Delete("secondYarr")))

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactorTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactorTest.scala
@@ -23,6 +23,7 @@ import better.files.File
 import com.comcast.xfinity.sirius.api.SiriusConfiguration
 import org.scalatest.BeforeAndAfterAll
 import com.comcast.xfinity.sirius.api.impl.{Delete, OrderedEvent}
+import com.comcast.xfinity.sirius.uberstore.data.{RandomAccessFileHandleFactory, UberDataFileHandleFactory}
 import org.mockito.Mockito._
 
 class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
@@ -37,15 +38,25 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
     dir
   }
 
+  def fileHandleFactory: UberDataFileHandleFactory = RandomAccessFileHandleFactory
+
   def writeEvents(segment: Segment, events: List[Long], timestamp: Long = 0L) {
     for (i <- events) {
       segment.writeEntry(OrderedEvent(i, timestamp, Delete(i.toString)))
     }
   }
 
-  def makeSegment(fullPath: String): Segment = {
+  def buildSegment(location: JFile): Segment = {
+    Segment(location, fileHandleFactory)
+  }
+
+  def buildSegment(base: JFile, name: String): Segment = {
+    Segment(base, name, fileHandleFactory)
+  }
+
+  def buildSegment(fullPath: String): Segment = {
     val file = new JFile(fullPath)
-    Segment(file.getParentFile, file.getName)
+    buildSegment(file.getParentFile, file.getName)
   }
 
   def listEvents(segment: Segment) =
@@ -65,8 +76,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
   describe("replace") {
     it("should replace the contents of the original segment with those of the replacement") {
-      val original = Segment(dir, "1")
-      val replacement = Segment(dir, "1.compacted")
+      val original = buildSegment(dir, "1")
+      val replacement = buildSegment(dir, "1.compacted")
       val foldFun = (acc: List[Long], evt: OrderedEvent) => evt.sequence :: acc
 
       writeEvents(original, List(1L, 2L, 3L, 4L))
@@ -74,7 +85,7 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
       val expected = replacement.foldLeft(List[Long]())(foldFun)
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       val result = segmentedCompactor.replace(original, replacement.location.getAbsolutePath)
 
       assert(original.location.getAbsolutePath === result.location.getAbsolutePath)
@@ -82,15 +93,15 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
     }
 
     it("should handle an empty replacement normally") {
-      val original = Segment(dir, "1")
-      val replacement = Segment(dir, "1.compacted")
+      val original = buildSegment(dir, "1")
+      val replacement = buildSegment(dir, "1.compacted")
       val foldFun = (acc: List[Long], evt: OrderedEvent) => evt.sequence :: acc
 
       writeEvents(original, List(1L, 2L, 3L, 4L))
 
       val expected = List[Long]()
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       val result = segmentedCompactor.replace(original, replacement.location.getAbsolutePath)
 
       assert(original.location.getAbsolutePath === result.location.getAbsolutePath)
@@ -101,7 +112,7 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
   describe("findCompactableSegments") {
     it("should return an empty List if no segments are provided") {
       val list = List[Segment]()
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       assert(List() === segmentedCompactor.findCompactableSegments(list))
     }
 
@@ -111,7 +122,7 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
       doReturn(true).when(mockSegment).isApplied
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       assert(List() === segmentedCompactor.findCompactableSegments(list))
     }
 
@@ -123,14 +134,14 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
       doReturn(true).when(appliedSegment).isApplied
       doReturn(false).when(notAppliedSegment).isApplied
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       assert(List(notAppliedSegment) === segmentedCompactor.findCompactableSegments(list))
     }
   }
 
   describe("compactInternally") {
     it("should remove earlier entries for duplicate keys within the segment") {
-      val segment = Segment(dir, "1")
+      val segment = buildSegment(dir, "1")
       List(
         OrderedEvent(1L, 0L, Delete("1")),
         OrderedEvent(2L, 0L, Delete("2")),
@@ -139,35 +150,35 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
         OrderedEvent(5L, 0L, Delete("5"))
       ).foreach(segment.writeEntry)
 
-      val underTest = SegmentedCompactor(new SiriusConfiguration())
-      val compacted = makeSegment(underTest.compactInternally(segment))
+      val underTest = SegmentedCompactor(siriusConfig, buildSegment)
+      val compacted = buildSegment(underTest.compactInternally(segment))
 
       val seqs = compacted.foldLeft(List[Long]())((acc, evt) => evt.sequence +: acc).reverse
       assert(List(1L, 4L, 5L) === seqs)
       assert("1 2 5" === listEvents(compacted))
     }
     it("should do nothing if there are no duplicate keys") {
-      val segment = Segment(dir, "1")
+      val segment = buildSegment(dir, "1")
       writeEvents(segment, List(1L, 2L, 3L, 4L))
 
-      val underTest = SegmentedCompactor(new SiriusConfiguration())
-      val compacted = makeSegment(underTest.compactInternally(segment))
+      val underTest = SegmentedCompactor(siriusConfig, buildSegment)
+      val compacted = buildSegment(underTest.compactInternally(segment))
       assert("1 2 3 4" === listEvents(compacted))
     }
     it("should set the internallyCompacted flag to true") {
-      val segment = Segment(dir, "1")
+      val segment = buildSegment(dir, "1")
 
-      val underTest = SegmentedCompactor(new SiriusConfiguration())
-      val compacted = makeSegment(underTest.compactInternally(segment))
+      val underTest = SegmentedCompactor(siriusConfig, buildSegment)
+      val compacted = buildSegment(underTest.compactInternally(segment))
 
       assert(true === compacted.isInternallyCompacted)
     }
     it("should preserve the keys-applied flag") {
-      val segment = Segment(dir, "1")
+      val segment = buildSegment(dir, "1")
       segment.setApplied(applied = true)
 
-      val underTest = SegmentedCompactor(new SiriusConfiguration())
-      val compacted = makeSegment(underTest.compactInternally(segment))
+      val underTest = SegmentedCompactor(siriusConfig, buildSegment)
+      val compacted = buildSegment(underTest.compactInternally(segment))
 
       assert(true === compacted.isApplied)
     }
@@ -175,23 +186,23 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
   describe("findInternalCompactionCandidates") {
     it("should return an empty list if all segments are internally compacted") {
-      val (one, two, three) = (Segment(dir, "1"), Segment(dir, "2"), Segment(dir, "3"))
+      val (one, two, three) = (buildSegment(dir, "1"), buildSegment(dir, "2"), buildSegment(dir, "3"))
       one.setInternallyCompacted(compacted = true)
       two.setInternallyCompacted(compacted = true)
       three.setInternallyCompacted(compacted = true)
 
-      val underTest = SegmentedCompactor(new SiriusConfiguration())
+      val underTest = SegmentedCompactor(siriusConfig, buildSegment)
       val candidates = underTest.findInternalCompactionCandidates(List(one, two, three))
 
       assert(List() === candidates)
     }
     it("should return only the segments that have not been internally compacted") {
-      val (one, two, three) = (Segment(dir, "1"), Segment(dir, "2"), Segment(dir, "3"))
+      val (one, two, three) = (buildSegment(dir, "1"), buildSegment(dir, "2"), buildSegment(dir, "3"))
       one.setInternallyCompacted(compacted = true)
       two.setInternallyCompacted(compacted = false)
       three.setInternallyCompacted(compacted = true)
 
-      val underTest = SegmentedCompactor(new SiriusConfiguration())
+      val underTest = SegmentedCompactor(siriusConfig, buildSegment)
       val candidates = underTest.findInternalCompactionCandidates(List(one, two, three))
 
       assert(List(two) === candidates)
@@ -200,52 +211,52 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
   describe("compactAgainst") {
     it("should fail if one of the segments to compact has not been internally compacted") {
-      val first = Segment(dir, "1")
-      val second = Segment(dir, "2")
+      val first = buildSegment(dir, "1")
+      val second = buildSegment(dir, "2")
       val segments = List(first)
 
       first.setInternallyCompacted(compacted = false)
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       intercept[IllegalStateException] {
         segmentedCompactor.compactAgainst(second, segments)
       }
     }
     it("should preserve a false isApplied flag when a segment is compacted") {
-      val first = Segment(dir, "1")
-      val second = Segment(dir, "2")
+      val first = buildSegment(dir, "1")
+      val second = buildSegment(dir, "2")
       val segments = List(first, second)
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
 
       first.setApplied(applied = false)
       first.setInternallyCompacted(compacted = true)
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       val compactionMap = segmentedCompactor.compactAgainst(second, segments)
-      assert(false === makeSegment(compactionMap(first)).isApplied)
+      assert(false === buildSegment(compactionMap(first)).isApplied)
     }
 
     it("should preserve a true isApplied flag when a segment is compacted") {
-      val first = Segment(dir, "1")
-      val second = Segment(dir, "2")
+      val first = buildSegment(dir, "1")
+      val second = buildSegment(dir, "2")
       val segments = List(first, second)
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
 
       first.setApplied(applied = true)
       first.setInternallyCompacted(compacted = true)
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       val compactionMap = segmentedCompactor.compactAgainst(second, segments)
-      assert(true === makeSegment(compactionMap(first)).isApplied)
+      assert(true === buildSegment(compactionMap(first)).isApplied)
     }
 
     it("should compact nothing if the supplied segment is the first in sort order") {
-      val first = Segment(dir, "1")
-      val second = Segment(dir, "2")
-      val third = Segment(dir, "3")
+      val first = buildSegment(dir, "1")
+      val second = buildSegment(dir, "2")
+      val third = buildSegment(dir, "3")
       val segments = List(first, second, third)
 
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       val compactionMap = segmentedCompactor.compactAgainst(first, segments)
 
       assert(None == compactionMap.get(first))
@@ -254,15 +265,15 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
     }
 
     it("should only compact Segments with name < supplied segment's name") {
-      val first = Segment(dir, "1")
-      val second = Segment(dir, "2")
-      val third = Segment(dir, "3")
+      val first = buildSegment(dir, "1")
+      val second = buildSegment(dir, "2")
+      val third = buildSegment(dir, "3")
       val segments = List(first, second, third)
 
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
       segments.foreach(_.setInternallyCompacted(compacted = true))
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       val compactionMap = segmentedCompactor.compactAgainst(second, segments)
 
       assert(None != compactionMap.get(first))
@@ -271,15 +282,15 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
     }
 
     it("should compact all other segments if the supplied segment is the latest") {
-      val first = Segment(dir, "1")
-      val second = Segment(dir, "2")
-      val third = Segment(dir, "3")
+      val first = buildSegment(dir, "1")
+      val second = buildSegment(dir, "2")
+      val third = buildSegment(dir, "3")
       val segments = List(first, second, third)
 
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
       segments.foreach(_.setInternallyCompacted(compacted = true))
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       val compactionMap = segmentedCompactor.compactAgainst(third, segments)
 
       assert(None != compactionMap.get(first))
@@ -288,15 +299,15 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
     }
 
     it("should compact all other segments if the supplied segment is the latest, regardless of list order") {
-      val first = Segment(dir, "1")
-      val second = Segment(dir, "2")
-      val third = Segment(dir, "3")
+      val first = buildSegment(dir, "1")
+      val second = buildSegment(dir, "2")
+      val third = buildSegment(dir, "3")
       val segments = List(third, second, first)
 
       segments.foreach(writeEvents(_, List(1L, 2L, 3L, 4L)))
       segments.foreach(_.setInternallyCompacted(compacted = true))
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       val compactionMap = segmentedCompactor.compactAgainst(third, segments)
 
       assert(None != compactionMap.get(first))
@@ -305,33 +316,33 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
     }
 
     it("should remove all events in appropriate segments that are overridden in the supplied segment when SOME events should be removed") {
-      val first = Segment(dir, "1")
-      val second = Segment(dir, "2")
+      val first = buildSegment(dir, "1")
+      val second = buildSegment(dir, "2")
       val segments = List(first, second)
 
       writeEvents(first, List(1L, 2L, 3L, 4L))
       writeEvents(second, List(3L, 4L, 5L, 6L))
       segments.foreach(_.setInternallyCompacted(compacted = true))
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       val compactionMap = segmentedCompactor.compactAgainst(second, segments)
-      val compacted = makeSegment(compactionMap(first))
+      val compacted = buildSegment(compactionMap(first))
 
       assert("1 2" === listEvents(compacted))
     }
 
     it("should remove all events in appropriate segments that are overridden in the supplied segment when ALL events should be removed") {
-      val first = Segment(dir, "1")
-      val second = Segment(dir, "2")
+      val first = buildSegment(dir, "1")
+      val second = buildSegment(dir, "2")
       val segments = List(first, second)
 
       writeEvents(first, List(1L, 2L, 3L, 4L))
       writeEvents(second, List(1L, 2L, 3L, 4L))
       segments.foreach(_.setInternallyCompacted(compacted = true))
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       val compactionMap = segmentedCompactor.compactAgainst(second, segments)
-      val compacted = makeSegment(compactionMap(first))
+      val compacted = buildSegment(compactionMap(first))
 
       assert(List(first) === compactionMap.keys.toList)
       assert("" === listEvents(compacted))
@@ -339,8 +350,8 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
   }
 
   it("should remove all Delete events in appropriate segments that are older than COMPACTION_MAX_DELETE_AGE_HOURS") {
-    val first = Segment(dir, "1")
-    val second = Segment(dir, "2")
+    val first = buildSegment(dir, "1")
+    val second = buildSegment(dir, "2")
     val segments = List(first, second)
 
     val now = System.currentTimeMillis()
@@ -353,17 +364,17 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
 
     val siriusConfigWithMaxAge = new SiriusConfiguration()
     siriusConfigWithMaxAge.setProp(SiriusConfiguration.COMPACTION_MAX_DELETE_AGE_HOURS, 1)
-    val segmentedCompactor = SegmentedCompactor(siriusConfigWithMaxAge)
+    val segmentedCompactor = SegmentedCompactor(siriusConfigWithMaxAge, buildSegment)
     val compactionMap = segmentedCompactor.compactAgainst(second, segments)
 
-    val compacted = makeSegment(compactionMap(first))
+    val compacted = buildSegment(compactionMap(first))
 
     assert("2" === listEvents(compacted))
   }
 
   it("should not remove any Delete events when COMPACTION_MAX_DELETE_AGE_HOURS is bigger than the current time") {
-    val first = Segment(dir, "1")
-    val second = Segment(dir, "2")
+    val first = buildSegment(dir, "1")
+    val second = buildSegment(dir, "2")
     val segments = List(first, second)
 
     val now = System.currentTimeMillis()
@@ -379,102 +390,102 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
     val biggerThanNowInHours = nowInHours + 168 // One week bigger than now, in hours
     siriusConfigWithMaxAge.setProp(SiriusConfiguration.COMPACTION_MAX_DELETE_AGE_HOURS, biggerThanNowInHours)
 
-    val segmentedCompactor = SegmentedCompactor(siriusConfigWithMaxAge)
+    val segmentedCompactor = SegmentedCompactor(siriusConfigWithMaxAge, buildSegment)
     val compactionMap = segmentedCompactor.compactAgainst(second, segments)
 
-    val compactedFirst = makeSegment(compactionMap(first))
+    val compactedFirst = buildSegment(compactionMap(first))
     assert("1 2" === listEvents(compactedFirst))
   }
 
   describe("findNextMergeableSegments") {
     it("should do nothing if the input is of size 0 or 1") {
       val isMergeable = (left: Segment, right: Segment) => true
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       assert(None === segmentedCompactor.findNextMergeableSegments(List(), isMergeable))
-      assert(None === segmentedCompactor.findNextMergeableSegments(List(Segment(dir, "1")), isMergeable))
+      assert(None === segmentedCompactor.findNextMergeableSegments(List(buildSegment(dir, "1")), isMergeable))
     }
 
     it("should return the first two elements if the return true for the isMergeable predicate") {
       val isMergeable = (left: Segment, right: Segment) => true
-      val (one, two, three) = (Segment(dir, "1"), Segment(dir, "2"), Segment(dir, "3"))
+      val (one, two, three) = (buildSegment(dir, "1"), buildSegment(dir, "2"), buildSegment(dir, "3"))
       val segments = List(one, two, three)
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       assert(Some(one, two) === segmentedCompactor.findNextMergeableSegments(segments, isMergeable))
     }
     it("should return None if there are no mergeable elements in the list") {
       val isMergeable = (left: Segment, right: Segment) => false
-      val (one, two, three) = (Segment(dir, "1"), Segment(dir, "2"), Segment(dir, "3"))
+      val (one, two, three) = (buildSegment(dir, "1"), buildSegment(dir, "2"), buildSegment(dir, "3"))
       val segments = List(one, two, three)
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       assert(None === segmentedCompactor.findNextMergeableSegments(segments, isMergeable))
     }
     it("should return the first mergeable elements in the list if there are any") {
       val isMergeable = (left: Segment, right: Segment) => left.name == "2" && right.name == "3"
-      val (one, two, three) = (Segment(dir, "1"), Segment(dir, "2"), Segment(dir, "3"))
+      val (one, two, three) = (buildSegment(dir, "1"), buildSegment(dir, "2"), buildSegment(dir, "3"))
       val segments = List(one, two, three)
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       assert(Some(two, three) === segmentedCompactor.findNextMergeableSegments(segments, isMergeable))
     }
   }
   describe("delete") {
     it("should close the input segment") {
-      val segment = Segment(dir, "1")
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segment = buildSegment(dir, "1")
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       segmentedCompactor.delete(segment)
       assert(true === segment.isClosed)
     }
     it("should remove the location of segment from the filesystem") {
-      val segment = Segment(dir, "1")
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segment = buildSegment(dir, "1")
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       segmentedCompactor.delete(segment)
       assert(false === segment.location.exists())
     }
   }
   describe("mergeSegments") {
     it("should create a new segment at targetFile") {
-      val (left, right) = (Segment(dir, "1"), Segment(dir, "2"))
+      val (left, right) = (buildSegment(dir, "1"), buildSegment(dir, "2"))
       val target = new JFile(dir, "1-2.merged")
 
       assert(false === target.exists())
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       segmentedCompactor.mergeSegments(left, right, target)
       assert(true === target.exists())
     }
     it("should write all of the elements from left and right into target, in order") {
-      val (left, right) = (Segment(dir, "1"), Segment(dir, "2"))
+      val (left, right) = (buildSegment(dir, "1"), buildSegment(dir, "2"))
       writeEvents(left, List(1L, 2L, 3L))
       writeEvents(right, List(4L, 5L, 6L))
       val target = new JFile(dir, "1-2.merged")
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       segmentedCompactor.mergeSegments(left, right, target)
 
-      assert("1 2 3 4 5 6" === listEvents(Segment(target)))
+      assert("1 2 3 4 5 6" === listEvents(buildSegment(target)))
     }
     it("should set the new segment's isApplied correctly if both left and right have been applied") {
-      val (left, right) = (Segment(dir, "1"), Segment(dir, "2"))
+      val (left, right) = (buildSegment(dir, "1"), buildSegment(dir, "2"))
       left.setApplied(applied = true)
       right.setApplied(applied = true)
       val target = new JFile(dir, "1-2.merged")
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       segmentedCompactor.mergeSegments(left, right, target)
 
-      assert(true === Segment(target).isApplied)
+      assert(true === buildSegment(target).isApplied)
     }
     it("should set the new segment's isApplied correctly if either left or right have not been applied") {
-      val (left, right) = (Segment(dir, "1"), Segment(dir, "2"))
+      val (left, right) = (buildSegment(dir, "1"), buildSegment(dir, "2"))
       left.setApplied(applied = false)
       right.setApplied(applied = true)
       val target = new JFile(dir, "1-2.merged")
 
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
       segmentedCompactor.mergeSegments(left, right, target)
 
-      assert(false === Segment(target).isApplied)
+      assert(false === buildSegment(target).isApplied)
     }
     it("should set the new segment's isInternallyCompacted correctly") {
       def createMerged(leftFile: JFile, rightFile: JFile, target: JFile)
@@ -484,17 +495,17 @@ class SegmentedCompactorTest extends NiceTest with BeforeAndAfterAll {
         File(rightFile.getPath).delete(swallowIOExceptions = true)
         File(target.getPath).delete(swallowIOExceptions = true)
 
-        val left = Segment(leftFile)
-        val right = Segment(rightFile)
+        val left = buildSegment(leftFile)
+        val right = buildSegment(rightFile)
 
         left.setApplied(leftApplied)
         left.setInternallyCompacted(leftCompacted)
         right.setApplied(rightApplied)
         right.setInternallyCompacted(rightCompacted)
 
-        val segmentedCompactor = SegmentedCompactor(new SiriusConfiguration())
+        val segmentedCompactor = SegmentedCompactor(new SiriusConfiguration(), buildSegment)
         segmentedCompactor.mergeSegments(left, right, target)
-        Segment(target)
+        buildSegment(target)
       }
 
       val (leftFile, rightFile) = (new JFile(dir, "1"), new JFile(dir, "2"))

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
@@ -24,6 +24,7 @@ import com.comcast.xfinity.sirius.api.impl._
 import com.comcast.xfinity.sirius.api.impl.OrderedEvent
 import com.comcast.xfinity.sirius.api.impl.Delete
 import com.comcast.xfinity.sirius.api.SiriusConfiguration
+import com.comcast.xfinity.sirius.uberstore.data.{RandomAccessFileHandleFactory, UberDataFileHandleFactory}
 
 class SegmentedUberStoreTest extends NiceTest {
 
@@ -36,6 +37,9 @@ class SegmentedUberStoreTest extends NiceTest {
     new JFile(tempDirName)
   }
 
+  val siriusConfig = new SiriusConfiguration
+  val fileHandleFactory: UberDataFileHandleFactory = RandomAccessFileHandleFactory
+
   def createSegment(baseDir: JFile, seq: String): JFile = {
     val dir = new JFile(baseDir, seq)
     dir.mkdir
@@ -46,7 +50,7 @@ class SegmentedUberStoreTest extends NiceTest {
   }
 
   def createPopulatedSegment(baseDir: JFile, name: String, events: List[Int], isApplied: Boolean = false) {
-    val segment = Segment(baseDir, name)
+    val segment = buildSegment(baseDir, name)
     segment.setApplied(applied = isApplied)
 
     writeEvents(segment, events.map(_.toLong))
@@ -67,10 +71,15 @@ class SegmentedUberStoreTest extends NiceTest {
     }
   }
 
-  def makeSegment(fullPath: String): Segment = {
+  def buildSegment(fullPath: String): Segment = {
     val file = new JFile(fullPath)
-    Segment(file.getParentFile, file.getName)
+    buildSegment(file.getParentFile, file.getName)
   }
+
+  def buildSegment(base: JFile, name: String): Segment =
+    Segment(base, name, fileHandleFactory)
+
+  def buildSegment(location: JFile): Segment = Segment(location, fileHandleFactory)
 
   def listEvents(segment: Segment) =
     segment.foldLeft(List[String]())((acc, event) => event.request.key :: acc).reverse.mkString(" ")
@@ -150,8 +159,8 @@ class SegmentedUberStoreTest extends NiceTest {
 
     it ("should split after the specified number of events have been written") {
       val siriusConfig = new SiriusConfiguration()
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
-      val underTest = new SegmentedUberStore(dir, 10L, segmentedCompactor)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
+      val underTest = new SegmentedUberStore(dir, 10L, segmentedCompactor, buildSegment)
 
       assert("1" === underTest.liveDir.name)
       writeUberStoreEvents(underTest, Range.inclusive(1, 10).toList)
@@ -199,8 +208,8 @@ class SegmentedUberStoreTest extends NiceTest {
   describe("compact") {
     it ("should perform a do-nothing compact of a single Segment, if |readOnlyDirs| == 1") {
       val siriusConfig = new SiriusConfiguration()
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
-      val underTest = new SegmentedUberStore(dir, 10L, segmentedCompactor)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
+      val underTest = new SegmentedUberStore(dir, 10L, segmentedCompactor, buildSegment)
 
       writeUberStoreEvents(underTest, Range.inclusive(1, 10).toList)
       underTest.compactAll()
@@ -212,8 +221,8 @@ class SegmentedUberStoreTest extends NiceTest {
 
     it ("should perform a real compact of Segment 1 if Segment 2 is read-only") {
       val siriusConfig = new SiriusConfiguration()
-      val segmentedCompactor = SegmentedCompactor(siriusConfig)
-      val underTest = new SegmentedUberStore(dir, 10L, segmentedCompactor)
+      val segmentedCompactor = SegmentedCompactor(siriusConfig, buildSegment)
+      val underTest = new SegmentedUberStore(dir, 10L, segmentedCompactor, buildSegment)
 
       writeUberStoreEvents(underTest, Range.inclusive(1, 10).toList)
       writeUberStoreEvents(underTest, Range.inclusive(6, 15).toList)
@@ -226,11 +235,11 @@ class SegmentedUberStoreTest extends NiceTest {
     }
 
     it ("should compact properly if presented with a number of non-compacted Segments") {
-      val first = Segment(dir, "1")
-      val second = Segment(dir, "2")
-      val third = Segment(dir, "3")
+      val first = buildSegment(dir, "1")
+      val second = buildSegment(dir, "2")
+      val third = buildSegment(dir, "3")
       // now we've just split
-      Segment(dir, "4")
+      buildSegment(dir, "4")
 
       val segments = List(first, second, third)
 
@@ -257,8 +266,8 @@ class SegmentedUberStoreTest extends NiceTest {
     }
 
     it ("should internally compact a single segment") {
-      val first = Segment(dir, "1")
-      Segment(dir, "2")
+      val first = buildSegment(dir, "1")
+      buildSegment(dir, "2")
 
       List(
         OrderedEvent(1L, 0L, Delete("1")),
@@ -276,9 +285,9 @@ class SegmentedUberStoreTest extends NiceTest {
       assert(List(1L, 2L, 5L, 6L) === seqs)
     }
     it("should remove both updates if a PUT is masked by a purge-able delete") {
-      val segment = Segment(dir, "1")
-      Segment(dir, "2") // to compact against
-      Segment(dir, "3") // currently active segment
+      val segment = buildSegment(dir, "1")
+      buildSegment(dir, "2") // to compact against
+      buildSegment(dir, "3") // currently active segment
 
       val now = System.currentTimeMillis()
       val twoHoursAgo = now - 2L * 60 * 60 * 1000
@@ -368,22 +377,22 @@ class SegmentedUberStoreTest extends NiceTest {
 
   describe("isMergeable") {
     it("should return false if the left segment has not been applied") {
-      val left = Segment(dir, "1")
-      val right = Segment(dir, "2")
+      val left = buildSegment(dir, "1")
+      val right = buildSegment(dir, "2")
       right.setApplied(applied = true)
 
       assert(false === SegmentedUberStore(dir.getAbsolutePath, new SiriusConfiguration).isMergeable(left, right))
     }
     it("should return false if the right segment has not been applied") {
-      val left = Segment(dir, "1")
-      val right = Segment(dir, "2")
+      val left = buildSegment(dir, "1")
+      val right = buildSegment(dir, "2")
       left.setApplied(applied = true)
 
       assert(false === SegmentedUberStore(dir.getAbsolutePath, new SiriusConfiguration).isMergeable(left, right))
     }
     it("should return false if the combined size of the segments > eventsPerSegment") {
-      val left = Segment(dir, "1")
-      val right = Segment(dir, "2")
+      val left = buildSegment(dir, "1")
+      val right = buildSegment(dir, "2")
       left.setApplied(applied = true)
       right.setApplied(applied = true)
 
@@ -396,8 +405,8 @@ class SegmentedUberStoreTest extends NiceTest {
       assert(false === SegmentedUberStore(dir.getAbsolutePath, config).isMergeable(left, right))
     }
     it("should return true if both are applied and combined size < eventsPerSegment") {
-      val left = Segment(dir, "1")
-      val right = Segment(dir, "2")
+      val left = buildSegment(dir, "1")
+      val right = buildSegment(dir, "2")
       left.setApplied(applied = true)
       right.setApplied(applied = true)
 
@@ -410,8 +419,8 @@ class SegmentedUberStoreTest extends NiceTest {
       assert(true === SegmentedUberStore(dir.getAbsolutePath, config).isMergeable(left, right))
     }
     it("should return true if both are applied and combined size == eventsPerSegment") {
-      val left = Segment(dir, "1")
-      val right = Segment(dir, "2")
+      val left = buildSegment(dir, "1")
+      val right = buildSegment(dir, "2")
       left.setApplied(applied = true)
       right.setApplied(applied = true)
 


### PR DESCRIPTION
Change Sirius read ops to use a `BufferedInputStream` over the underlying Uberstore files to improve performance, particularly around bootstrapping.

Rudimentary benchmark running XtvAPI locally on my Macbook Pro:

Sirius 1.2.6:
```
Finished firing up Session Sirius on HQSML-1685301:2553 in 501986 ms
Finished firing up Metadata Sirius on HQSML-1685301:2552 in 1237428 ms
```

Sirius 1.2.8-SNAPSHOT (with file op mods):
```
Finished firing up Session Sirius on HQSML-1685301:2553 in 187282 ms
Finished firing up Metadata Sirius on HQSML-1685301:2552 in 224490 ms
```