### PR TITLE
Add BrainlessRequestHandler case object to skip Sirius bootstrap

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/BrainlessRequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/BrainlessRequestHandler.scala
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2012-2014 Comcast Cable Communications Management, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.comcast.xfinity.sirius.api
 
 /**

--- a/src/main/scala/com/comcast/xfinity/sirius/api/BrainlessRequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/BrainlessRequestHandler.scala
@@ -1,0 +1,38 @@
+package com.comcast.xfinity.sirius.api
+
+/**
+  * Special instance of [[RequestHandler]] that indicates to Sirius to not bootstrap the in-memory brain
+  */
+case object BrainlessRequestHandler extends RequestHandler {
+  /**
+    * Handle a GET request
+    *
+    * @param key String identifying the search query
+    * @return a SiriusResult wrapping the result of the query
+    */
+  override def handleGet(key: String): SiriusResult = SiriusResult.none()
+
+  /**
+    * Handle a PUT request
+    *
+    * @param key  unique identifier for the item to which the
+    *             operation is being applied
+    * @param body data passed in along with this request used
+    *             for modifying the state at key
+    * @return a SiriusResult wrapping the result of the operation.
+    *         This should almost always be SiriusResult.none().
+    *         In the future the API may be modified to return void.
+    */
+  override def handlePut(key: String, body: Array[Byte]): SiriusResult = SiriusResult.none()
+
+  /**
+    * Handle a DELETE request
+    *
+    * @param key unique identifier for the item to which the
+    *            operation is being applied
+    * @return a SiriusResult wrapping the result of the operation.
+    *         This should almost always be SiriusResult.none().
+    *         In the future the API may be modified to return void.
+    */
+  override def handleDelete(key: String): SiriusResult = SiriusResult.none()
+}

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/SiriusFactory.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/SiriusFactory.scala
@@ -21,8 +21,7 @@ import java.net.InetAddress
 import java.util.{HashMap => JHashMap}
 
 import com.comcast.xfinity.sirius.admin.ObjectNameHelper
-import com.comcast.xfinity.sirius.api.RequestHandler
-import com.comcast.xfinity.sirius.api.SiriusConfiguration
+import com.comcast.xfinity.sirius.api.{BrainlessRequestHandler, RequestHandler, SiriusConfiguration}
 import com.comcast.xfinity.sirius.info.SiriusInfo
 import com.comcast.xfinity.sirius.writeaheadlog.CachedSiriusLog
 import com.comcast.xfinity.sirius.writeaheadlog.SiriusLog
@@ -82,6 +81,11 @@ object SiriusFactory {
 
     createInstance(requestHandler, siriusConfig, log)
   }
+
+  /**
+    * Helper method for returning the [[BrainlessRequestHandler]] case object instance
+    */
+  def brainlessRequestHandler(): RequestHandler = BrainlessRequestHandler
 
   /**
    * USE ONLY FOR TESTING HOOK WHEN YOU NEED TO MOCK OUT A LOG.

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/state/StateSup.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/state/StateSup.scala
@@ -15,13 +15,13 @@
  */
 package com.comcast.xfinity.sirius.api.impl.state
 
-import com.comcast.xfinity.sirius.api.{SiriusConfiguration, RequestHandler}
+import com.comcast.xfinity.sirius.api.{BrainlessRequestHandler, RequestHandler, SiriusConfiguration}
 import akka.agent.Agent
 import com.comcast.xfinity.sirius.writeaheadlog.SiriusLog
 import com.comcast.xfinity.sirius.api.impl._
 import akka.event.Logging
 import state.SiriusPersistenceActor.LogQuery
-import akka.actor.{ActorContext, Props, ActorRef, Actor}
+import akka.actor.{Actor, ActorContext, ActorRef, Props}
 import com.comcast.xfinity.sirius.admin.MonitoringHooks
 
 object StateSup {
@@ -112,26 +112,32 @@ class StateSup(requestHandler: RequestHandler,
 
   // TODO perhaps this should be pulled out into a BootstrapActor. The StateSup should really only supervise.
   private def bootstrapState() {
-    val start = System.currentTimeMillis
 
-    logger.info("Beginning SiriusLog replay at {}", start)
-    // TODO convert this to foreach
-    siriusLog.foldLeft(())(
-      (_, orderedEvent) =>
-        try {
-          orderedEvent.request match {
-            case Put(key, body) => requestHandler.handlePut(key, body)
-            case Delete(key) => requestHandler.handleDelete(key)
-          }
-        } catch {
-          case rte: RuntimeException =>
-            eventReplayFailureCount += 1
-            logger.error("Exception replaying {}: {}", orderedEvent, rte)
-        }
-    )
-    val totalBootstrapTime = System.currentTimeMillis - start
-    bootstrapTime = Some(totalBootstrapTime)
-    logger.info("Replayed SiriusLog in {}ms", totalBootstrapTime)
+    requestHandler match {
+      case BrainlessRequestHandler =>
+        logger.info("Skipping SiriusLog replay")
+        bootstrapTime = Some(0L)
+
+      case _ =>
+        val start = System.currentTimeMillis
+        logger.info("Beginning SiriusLog replay at {}", start)
+        siriusLog.foreach(
+          orderedEvent =>
+            try {
+              orderedEvent.request match {
+                case Put(key, body) => requestHandler.handlePut(key, body)
+                case Delete(key) => requestHandler.handleDelete(key)
+              }
+            } catch {
+              case rte: RuntimeException =>
+                eventReplayFailureCount += 1
+                logger.error("Exception replaying {}: {}", orderedEvent, rte)
+            }
+        )
+        val totalBootstrapTime = System.currentTimeMillis - start
+        bootstrapTime = Some(totalBootstrapTime)
+        logger.info("Replayed SiriusLog in {}ms", totalBootstrapTime)
+    }
   }
 
   trait StateInfoMBean {


### PR DESCRIPTION
We have a number of XtvAPI nodes that don't populate an in-memory brain but instead exist to facilitate Sirius.  This includes the ingest cluster which handle PAXOS consensus as well as nodes that are used strictly for Sirius catchup.  We pass no-op implementations of `RequestHandler` but Sirius still goes through a full replay of the Uberstore which can add 20-30 minutes to the time it takes to bootstrap the service.  As far as I could tell that replay only serves to populate the brain and other housekeeping such as index repair happen beforehand, so it should be safe to skip the log replay.

I propose a special `case object` implementation of `RequestHandler` that Sirius would recognize and if that is the instance of the `RequestHandler` passed to SiriusFactory then log replay will be skipped.