### PR TITLE
Backport Brainless request handler to Sirius 1.2.x

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/BrainlessRequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/BrainlessRequestHandler.scala
@@ -1,0 +1,38 @@
+package com.comcast.xfinity.sirius.api
+
+/**
+  * Special instance of [[RequestHandler]] that indicates to Sirius to not bootstrap the in-memory brain
+  */
+case object BrainlessRequestHandler extends RequestHandler {
+  /**
+    * Handle a GET request
+    *
+    * @param key String identifying the search query
+    * @return a SiriusResult wrapping the result of the query
+    */
+  override def handleGet(key: String): SiriusResult = SiriusResult.none()
+
+  /**
+    * Handle a PUT request
+    *
+    * @param key  unique identifier for the item to which the
+    *             operation is being applied
+    * @param body data passed in along with this request used
+    *             for modifying the state at key
+    * @return a SiriusResult wrapping the result of the operation.
+    *         This should almost always be SiriusResult.none().
+    *         In the future the API may be modified to return void.
+    */
+  override def handlePut(key: String, body: Array[Byte]): SiriusResult = SiriusResult.none()
+
+  /**
+    * Handle a DELETE request
+    *
+    * @param key unique identifier for the item to which the
+    *            operation is being applied
+    * @return a SiriusResult wrapping the result of the operation.
+    *         This should almost always be SiriusResult.none().
+    *         In the future the API may be modified to return void.
+    */
+  override def handleDelete(key: String): SiriusResult = SiriusResult.none()
+}

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/SiriusFactory.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/SiriusFactory.scala
@@ -21,8 +21,7 @@ import java.net.InetAddress
 import java.util.{HashMap => JHashMap}
 
 import com.comcast.xfinity.sirius.admin.ObjectNameHelper
-import com.comcast.xfinity.sirius.api.RequestHandler
-import com.comcast.xfinity.sirius.api.SiriusConfiguration
+import com.comcast.xfinity.sirius.api.{BrainlessRequestHandler, RequestHandler, SiriusConfiguration}
 import com.comcast.xfinity.sirius.info.SiriusInfo
 import com.comcast.xfinity.sirius.writeaheadlog.CachedSiriusLog
 import com.comcast.xfinity.sirius.writeaheadlog.SiriusLog
@@ -80,6 +79,11 @@ object SiriusFactory {
 
     createInstance(requestHandler, siriusConfig, log)
   }
+
+  /**
+    * Helper method for returning the [[BrainlessRequestHandler]] case object instance
+    */
+  def brainlessRequestHandler(): RequestHandler = BrainlessRequestHandler
 
   /**
    * USE ONLY FOR TESTING HOOK WHEN YOU NEED TO MOCK OUT A LOG.


### PR DESCRIPTION
Backports the BrainlessRequestHandler to Sirius 1.2.x to enable skipping bootstrap when not populating a Sirius brain.