### PR TITLE
Explicitly specify Java 8 for TravisCI for Scala 2.10 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+dist: trusty
 language: scala
 scala:
    - 2.10.2
+sudo: false
+jdk:
+   - oraclejdk8


### PR DESCRIPTION
CI builds are failing due to TravisCI using OpenJDK 11 with which Scala 2.10 is not compatible.