### PR TITLE
Release v1.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@
 
 name := "sirius"
 
-version := "1.2.6"
+version := "1.3.0"
 
 scalaVersion := "2.10.2"
 


### PR DESCRIPTION
Backport from 2.x branch:

* fdab13f Backport Brainless request handler to Sirius 1.2.x (PR #141)
* 975e436 Explicitly specify Java 8 for TravisCI for Scala 2.10 builds (PR #144)
* 9810305 Backport Buffered Streaming I/O to Sirius 1.2.x (PR #138)