### PR TITLE
Release v2.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@
 
 name := "sirius"
 
-version := "2.1.1-SNAPSHOT"
+version := "2.2.0"
 
 scalaVersion := "2.12.8"
 crossScalaVersions := Seq("2.11.8", "2.12.8")


### PR DESCRIPTION
Two major changes:

* a4e46d3 Add BrainlessRequestHandler case object to skip Sirius bootstrap (PR #137)
  Add a request handler that's essentially a no-op, for clusters that
  don't actually need to store the data in-memory (ingest clusters).
  Replay is skipped for this handler, so startup is very fast.

* 9660a1f Use BufferedInputStream for read operations (PR #136)
  Optionally configure buffered read of the UberStore, which
  dramatically reduces replay time.

Thanks @HaloFour for all the excellent work 🌮 