### PR TITLE
Avoid using Java NIO Files.list which appears to leak read handles to the target directory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ libraryDependencies ++= {
     "com.typesafe.akka"             %% "akka-slf4j"                     % akkaV,
     "com.typesafe.akka"             %% "akka-agent"                     % akkaV,
     "org.slf4j"                     %  "slf4j-api"                      % "1.7.7",
-    "com.github.pathikrit"          %% "better-files"                   % "3.7.0", 
+    "com.github.pathikrit"          %% "better-files"                   % "3.8.0",
     "org.scalatest"                 %% "scalatest"                      % "3.0.5"   % "test",
     "org.mockito"                   %  "mockito-core"                   % "1.10.19" % "test",
     "junit"                         %  "junit"                          % "4.12"    % "test",

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedCompactor.scala
@@ -16,8 +16,7 @@
 package com.comcast.xfinity.sirius.uberstore.segmented
 
 import com.comcast.xfinity.sirius.api.impl.{Delete, OrderedEvent}
-import java.io.{IOException, File => JFile}
-import java.nio.file.{Files, Path}
+import java.io.{File => JFile}
 
 import annotation.tailrec
 import java.util
@@ -59,26 +58,9 @@ private [segmented] class SegmentedCompactor(maxDeleteAgeMillis: Long, buildSegm
 
     originalPath.moveTo(tempPath)
     replacementPath.moveTo(originalPath)
-    // do not use tempPath.delete(), this calls Files.list() which leaks read handles
-    deleteRecursively(tempPath.path)
+    tempPath.delete()
 
     buildSegment(original.location.getParentFile, original.location.getName)
-  }
-
-  private def deleteRecursively(path: Path): Unit = {
-    try {
-      if (Files.isDirectory(path)) {
-        Option(path.toFile.listFiles()) match {
-          case Some(children) => children
-            .map { _.toPath }
-            .foreach { deleteRecursively }
-          case _ =>
-        }
-      }
-      Files.delete(path)
-    } catch {
-      case e: IOException => e.printStackTrace(System.out)
-    }
   }
 
   /**


### PR DESCRIPTION
There appears to be a bug in Java NIO2 `Files.list` that causes read handles to the directory to never close.  The `better-files` Scala library uses this method for recursively deleting a directory, which is used by Sirius during compaction and over time results in too many handles being open and crashing the process.

The older Java 1.2 API doesn't exhibit this behavior, so wrote a separate recursive delete function which uses that API instead.