### PR TITLE
Explore parallelization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ name := "sirius"
 
 version := "2.4.0"
 
-scalaVersion := "2.12.14"
+scalaVersion := "2.13.6"
 crossScalaVersions := Seq("2.11.12", "2.12.14", "2.13.6") // NOTE: keep sync'd with .travis.yml
 
 organization := "com.comcast"
@@ -53,7 +53,7 @@ libraryDependencies ++= {
 libraryDependencies ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, major)) if major <= 12 =>
-      Seq("org.scala-lang.modules" %% "scala-collection-compat" % "2.12.0")
+      Seq()
     case _ =>
       Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4")
   }

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ name := "sirius"
 
 version := "2.4.0"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.12.14"
 crossScalaVersions := Seq("2.11.12", "2.12.14", "2.13.6") // NOTE: keep sync'd with .travis.yml
 
 organization := "com.comcast"
@@ -48,6 +48,15 @@ libraryDependencies ++= {
     "log4j"                         %  "log4j"                          % "1.2.17"    % Test,
     "com.typesafe.akka"             %% "akka-testkit"                   % akkaV       % Test
   )
+}
+
+libraryDependencies ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, major)) if major <= 12 =>
+      Seq("org.scala-lang.modules" %% "scala-collection-compat" % "2.12.0")
+    case _ =>
+      Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4")
+  }
 }
 
 // Set the artifact names.

--- a/src/main/scala-2.11/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
+++ b/src/main/scala-2.11/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
@@ -1,0 +1,3 @@
+package com.comcast.xfinity.sirius.uberstore.segmented
+
+object ParallelHelpers { }

--- a/src/main/scala-2.11/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
+++ b/src/main/scala-2.11/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
@@ -1,3 +1,7 @@
 package com.comcast.xfinity.sirius.uberstore.segmented
 
-object ParallelHelpers { }
+import scala.collection.parallel.ParSeq
+
+object ParallelHelpers {
+    def parallelize[T](seq: Seq[T]): ParSeq[T] = seq.par
+}

--- a/src/main/scala-2.12/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
+++ b/src/main/scala-2.12/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
@@ -5,4 +5,3 @@ import scala.collection.parallel.ParSeq
 object ParallelHelpers {
     def parallelize[T](seq: Seq[T]): ParSeq[T] = seq.par
 }
-

--- a/src/main/scala-2.12/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
+++ b/src/main/scala-2.12/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
@@ -1,0 +1,8 @@
+package com.comcast.xfinity.sirius.uberstore.segmented
+
+import scala.collection.parallel.immutable.ParSeq
+
+object ParallelHelpers {
+    def parallelize[T](seq: Seq[T]): ParSeq[T] = seq.par
+}
+

--- a/src/main/scala-2.12/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
+++ b/src/main/scala-2.12/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
@@ -1,6 +1,6 @@
 package com.comcast.xfinity.sirius.uberstore.segmented
 
-import scala.collection.parallel.immutable.ParSeq
+import scala.collection.parallel.ParSeq
 
 object ParallelHelpers {
     def parallelize[T](seq: Seq[T]): ParSeq[T] = seq.par

--- a/src/main/scala-2.13/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
+++ b/src/main/scala-2.13/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
@@ -1,0 +1,8 @@
+package com.comcast.xfinity.sirius.uberstore.segmented
+
+import scala.collection.parallel.immutable.ParSeq
+import scala.collection.parallel.CollectionConverters._
+
+object ParallelHelpers {
+    def parallelize[T](seq: Seq[T]): ParSeq[T] = seq.par
+}

--- a/src/main/scala-2.13/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
+++ b/src/main/scala-2.13/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
@@ -1,7 +1,7 @@
 package com.comcast.xfinity.sirius.uberstore.segmented
 
-import scala.collection.parallel.immutable.ParSeq
 import scala.collection.parallel.CollectionConverters._
+import scala.collection.parallel.ParSeq
 
 object ParallelHelpers {
     def parallelize[T](seq: Seq[T]): ParSeq[T] = seq.par

--- a/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
@@ -308,6 +308,11 @@ object SiriusConfiguration {
    * Maximum akka message size in KB. Default is 1024. Type is Integer.
    */
   final val MAX_AKKA_MESSAGE_SIZE_KB = "sirius.akka.maximum-frame-size-kb"
+
+  /**
+   * Whether or not to bootstrap the log in parallel, only applies to segmented uberstores
+   */
+  final val LOG_PARALLEL_ENABLED = "sirius.log.parallel-enabled"
 }
 
 /**

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
@@ -135,11 +135,8 @@ class SegmentedUberStore private[segmented] (base: JFile,
    */
   def getNextSeq = nextSeq
 
-  override def foreach[T](parallel: Boolean, fun: OrderedEvent => T): Unit =
-    if (parallel) parallelForeach(fun) else foldLeft(())((_, e) => fun(e))
-
-  private def parallelForeach[T](fun: OrderedEvent => T): Unit = {
-    ParallelHelpers.parallelize(liveDir :: readOnlyDirs).foldLeft(())(
+  override def parallelForeach[T](fun: OrderedEvent => T): Unit = {
+    ParallelHelpers.parallelize(readOnlyDirs ::: liveDir :: Nil).foldLeft(())(
       (_, dir) => dir.foldLeftRange(0, Long.MaxValue)(())((_, e) => fun(e))
     )
   }

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
@@ -136,9 +136,8 @@ class SegmentedUberStore private[segmented] (base: JFile,
   def getNextSeq = nextSeq
 
   override def parallelForeach[T](fun: OrderedEvent => T): Unit = {
-    ParallelHelpers.parallelize(readOnlyDirs ::: liveDir :: Nil).foldLeft(())(
-      (_, dir) => dir.foldLeftRange(0, Long.MaxValue)(())((_, e) => fun(e))
-    )
+    ParallelHelpers.parallelize(readOnlyDirs :+ liveDir)
+            .foreach(_.foldLeftRange(0, Long.MaxValue)(())((_, e) => fun(e)))
   }
 
   /**

--- a/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/SiriusLog.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/SiriusLog.scala
@@ -34,15 +34,14 @@ trait SiriusLog {
    *
    * @param fun function to apply
    */
-  def foreach[T](fun: OrderedEvent => T): Unit = foreach[T](parallel = false, fun)
+  def foreach[T](fun: OrderedEvent => T): Unit = foldLeft(())((_, e) => fun(e))
 
   /**
-   * Apply fun to each entry in the log, optionally parallel and out of order
+   * Apply fun to each entry in the log in parallel and potentially out of order
    *
-   * @param parallel scan in parallel and out of order
    * @param fun function to apply
    */
-  def foreach[T](parallel: Boolean, fun: OrderedEvent => T): Unit = foldLeft(())((_, e) => fun(e))
+  def parallelForeach[T](fun: OrderedEvent => T): Unit = foreach[T](fun)
 
   /**
    * Fold left across the log entries

--- a/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/SiriusLog.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/SiriusLog.scala
@@ -34,7 +34,15 @@ trait SiriusLog {
    *
    * @param fun function to apply
    */
-  def foreach[T](fun: OrderedEvent => T): Unit = foldLeft(())((_, e) => fun(e))
+  def foreach[T](fun: OrderedEvent => T): Unit = foreach[T](parallel = false, fun)
+
+  /**
+   * Apply fun to each entry in the log, optionally parallel and out of order
+   *
+   * @param parallel scan in parallel and out of order
+   * @param fun function to apply
+   */
+  def foreach[T](parallel: Boolean, fun: OrderedEvent => T): Unit = foldLeft(())((_, e) => fun(e))
 
   /**
    * Fold left across the log entries

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
@@ -16,6 +16,8 @@
 
 package com.comcast.xfinity.sirius.uberstore.segmented
 
+import scala.collection.concurrent._
+
 import com.comcast.xfinity.sirius.NiceTest
 import java.io.{File => JFile}
 
@@ -192,6 +194,21 @@ class SegmentedUberStoreTest extends NiceTest {
           (acc, event) => event.request +: acc
         ).reverse
       )
+    }
+  }
+
+  describe("parallelForeach") {
+    it("should bootstrap the uberstore in parallel") {
+      createPopulatedSegment(dir, "1", Range.inclusive(1, 3).toList, isApplied = true)
+      createPopulatedSegment(dir, "2", Range.inclusive(4, 6).toList, isApplied = true)
+      createPopulatedSegment(dir, "3", Range.inclusive(7, 9).toList, isApplied = true)
+      val config = new SiriusConfiguration
+      config.setProp(SiriusConfiguration.LOG_PARALLEL_ENABLED, true)
+      uberstore = SegmentedUberStore(dir.getAbsolutePath, config)
+      val map = new TrieMap[Long, SiriusRequest]()
+      uberstore.parallelForeach(event => map.put(event.sequence, event.request))
+
+      assert(map.size == 9)
     }
   }
 


### PR DESCRIPTION
Adds an option to bootstrap a segmented uberstore in parallel, so that each segment can be processed separately by the request handler.  This does result in events being processed out of order and requires the implementation of the brain to be able to handle the book keeping to ensure that only the newest events are preserved.