### PR TITLE
Implementation of RequestHandler to support parallel out-of-order bootstrapping

### DIFF
--- a/src/main/scala-2.11/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
+++ b/src/main/scala-2.11/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
@@ -3,5 +3,7 @@ package com.comcast.xfinity.sirius.uberstore.segmented
 import scala.collection.parallel.ParSeq
 
 object ParallelHelpers {
-    def parallelize[T](seq: Seq[T]): ParSeq[T] = seq.par
+    implicit class ParSeqConverter[T](private val seq: Seq[T]) {
+        def parallelize: ParSeq[T] = seq.par
+    }
 }

--- a/src/main/scala-2.12/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
+++ b/src/main/scala-2.12/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
@@ -3,5 +3,7 @@ package com.comcast.xfinity.sirius.uberstore.segmented
 import scala.collection.parallel.ParSeq
 
 object ParallelHelpers {
-    def parallelize[T](seq: Seq[T]): ParSeq[T] = seq.par
+    implicit class ParSeqConverter[T](private val seq: Seq[T]) {
+        def parallelize: ParSeq[T] = seq.par
+    }
 }

--- a/src/main/scala-2.13/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
+++ b/src/main/scala-2.13/com/comcast/xfinity/sirius/uberstore/segmented/ParallelHelpers.scala
@@ -4,5 +4,7 @@ import scala.collection.parallel.CollectionConverters._
 import scala.collection.parallel.ParSeq
 
 object ParallelHelpers {
-    def parallelize[T](seq: Seq[T]): ParSeq[T] = seq.par
+    implicit class ParSeqConverter[T](private val seq: Seq[T]) {
+        def parallelize: ParSeq[T] = seq.par
+    }
 }

--- a/src/main/scala/com/comcast/xfinity/sirius/api/AbstractParallelBootstrapRequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/AbstractParallelBootstrapRequestHandler.scala
@@ -1,0 +1,72 @@
+package com.comcast.xfinity.sirius.api
+
+import java.util.concurrent.ConcurrentHashMap
+
+abstract class AbstractParallelBootstrapRequestHandler[K, M] extends RequestHandler {
+    private var sequences: Option[ConcurrentHashMap[K, Long]] = None
+
+    override def onBootstrapStarting(): Unit = {
+        sequences = Some(new ConcurrentHashMap[K, Long]())
+    }
+
+    override def onBootstrapComplete(): Unit = {
+        sequences = None
+    }
+
+    override def handleGet(key: String): SiriusResult =
+        if (enabled()) handleGetImpl(createKey(key))
+        else SiriusResult.none()
+
+    override def handlePut(key: String, body: Array[Byte]): SiriusResult =
+        if (enabled()) handlePutImpl(createKey(key), deserialize(body))
+        else SiriusResult.none()
+
+    override def handleDelete(key: String): SiriusResult =
+        if (enabled()) handleDeleteImpl(createKey(key))
+        else SiriusResult.none()
+
+    override def handlePut(sequence: Long, key: String, body: Array[Byte]): SiriusResult =
+        if (enabled())
+            sequences match {
+                case Some(map) =>
+                    val k = createKey(key)
+                    val existing = map.get(k)
+                    if (existing < sequence) {
+                        var result: SiriusResult = SiriusResult.none()
+                        val message = deserialize(body)
+                        map.compute(k, (_, existing) => {
+                            if (existing < sequence) {
+                                result = handlePutImpl(sequence, k, message)
+                                sequence
+                            } else existing
+                        })
+                        result
+                    } else SiriusResult.none()
+                case None => handlePutImpl(sequence, createKey(key), deserialize(body))
+            }
+        else SiriusResult.none()
+
+    override def handleDelete(sequence: Long, key: String): SiriusResult =
+        sequences match {
+            case Some(map) =>
+                var result: SiriusResult = SiriusResult.none()
+                map.compute(createKey(key), (k, existing) => {
+                    if (existing < sequence) {
+                        result = handleDeleteImpl(sequence, k)
+                        sequence
+                    } else existing
+                })
+                result
+            case None => handleDeleteImpl(sequence, createKey(key))
+        }
+
+    protected def enabled(): Boolean
+    protected def createKey(key: String): K
+    protected def deserialize(body: Array[Byte]): M
+
+    def handleGetImpl(key: K): SiriusResult
+    def handlePutImpl(key: K, body: M): SiriusResult
+    def handleDeleteImpl(key: K): SiriusResult
+    def handlePutImpl(sequence: Long, key: K, body: M): SiriusResult = handlePutImpl(key, body)
+    def handleDeleteImpl(sequence:Long, key: K): SiriusResult = handleDeleteImpl(key)
+}

--- a/src/main/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandler.scala
@@ -1,50 +1,27 @@
 package com.comcast.xfinity.sirius.api
 
-import java.util.concurrent.ConcurrentHashMap
+object ParallelBootstrapRequestHandler {
+    def apply(requestHandler: RequestHandler): ParallelBootstrapRequestHandler =
+        new ParallelBootstrapRequestHandler(requestHandler)
+}
 
-class ParallelBootstrapRequestHandler(val requestHandler: RequestHandler) extends RequestHandler {
-    private var sequences: ConcurrentHashMap[String, Long] = _
-
-    override def handleGet(key: String): SiriusResult = requestHandler.handleGet(key)
-    override def handlePut(key: String, body: Array[Byte]): SiriusResult = requestHandler.handlePut(key, body)
-    override def handleDelete(key: String): SiriusResult = requestHandler.handleDelete(key)
+class ParallelBootstrapRequestHandler(val requestHandler: RequestHandler) extends AbstractParallelBootstrapRequestHandler[String, Array[Byte]] {
+    override protected def enabled(): Boolean = true
+    override protected def createKey(key: String): String = key
+    override protected def deserialize(body: Array[Byte]): Array[Byte] = body
+    override def handleGetImpl(key: String): SiriusResult = requestHandler.handleGet(key)
+    override def handlePutImpl(key: String, body: Array[Byte]): SiriusResult = requestHandler.handlePut(key, body)
+    override def handleDeleteImpl(key: String): SiriusResult = requestHandler.handleDelete(key)
+    override def handlePutImpl(sequence: Long, key: String, body: Array[Byte]): SiriusResult = requestHandler.handlePut(sequence, key, body)
+    override def handleDeleteImpl(sequence: Long, key: String): SiriusResult = requestHandler.handleDelete(sequence, key)
 
     override def onBootstrapStarting(): Unit = {
-        sequences = new ConcurrentHashMap[String, Long]()
+        super.onBootstrapStarting()
         requestHandler.onBootstrapStarting()
     }
 
     override def onBootstrapComplete(): Unit = {
-        // allow the GC to collect the map
-        sequences = null
+        super.onBootstrapComplete()
         requestHandler.onBootstrapComplete()
-    }
-
-    override def handlePut(sequence: Long, key: String, body: Array[Byte]): SiriusResult = {
-        latest(key, sequence) {
-            requestHandler.handlePut(sequence, key, body)
-        }
-    }
-
-    override def handleDelete(sequence: Long, key: String): SiriusResult = {
-        latest(key, sequence) {
-            requestHandler.handleDelete(sequence, key)
-        }
-    }
-
-    private def latest(key: String, sequence: Long)(f: => SiriusResult) = {
-        val sequences = this.sequences
-        if (sequences != null) {
-            var result = SiriusResult.none()
-            sequences.compute(key, (_, existing) => {
-                if (existing < sequence) {
-                    result = f
-                    sequence
-                } else existing
-            })
-            result
-        } else {
-            f
-        }
     }
 }

--- a/src/main/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandler.scala
@@ -3,12 +3,16 @@ package com.comcast.xfinity.sirius.api
 import java.util.concurrent.ConcurrentHashMap
 
 class ParallelBootstrapRequestHandler(val requestHandler: RequestHandler) extends RequestHandler {
-    private var sequences = new ConcurrentHashMap[String, Long]
+    private var sequences: ConcurrentHashMap[String, Long] = _
 
-    override def onBootstrapStarting(): Unit = requestHandler.onBootstrapStarting()
     override def handleGet(key: String): SiriusResult = requestHandler.handleGet(key)
     override def handlePut(key: String, body: Array[Byte]): SiriusResult = requestHandler.handlePut(key, body)
     override def handleDelete(key: String): SiriusResult = requestHandler.handleDelete(key)
+
+    override def onBootstrapStarting(): Unit = {
+        sequences = new ConcurrentHashMap[String, Long]()
+        requestHandler.onBootstrapStarting()
+    }
 
     override def onBootstrapComplete(): Unit = {
         // allow the GC to collect the map

--- a/src/main/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandler.scala
@@ -15,13 +15,6 @@ class ParallelBootstrapRequestHandler(val requestHandler: RequestHandler) extend
     override def handlePutImpl(sequence: Long, key: String, body: Array[Byte]): SiriusResult = requestHandler.handlePut(sequence, key, body)
     override def handleDeleteImpl(sequence: Long, key: String): SiriusResult = requestHandler.handleDelete(sequence, key)
 
-    override def onBootstrapStarting(): Unit = {
-        super.onBootstrapStarting()
-        requestHandler.onBootstrapStarting()
-    }
-
-    override def onBootstrapComplete(): Unit = {
-        super.onBootstrapComplete()
-        requestHandler.onBootstrapComplete()
-    }
+    override def onBootstrapStartingImpl(): Unit = requestHandler.onBootstrapStarting()
+    override def onBootstrapCompletedImpl(): Unit = requestHandler.onBootstrapComplete()
 }

--- a/src/main/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandler.scala
@@ -1,0 +1,46 @@
+package com.comcast.xfinity.sirius.api
+
+import java.util.concurrent.ConcurrentHashMap
+
+class ParallelBootstrapRequestHandler(val requestHandler: RequestHandler) extends RequestHandler {
+    private var sequences = new ConcurrentHashMap[String, Long]
+
+    override def onBootstrapStarting(): Unit = requestHandler.onBootstrapStarting()
+    override def handleGet(key: String): SiriusResult = requestHandler.handleGet(key)
+    override def handlePut(key: String, body: Array[Byte]): SiriusResult = requestHandler.handlePut(key, body)
+    override def handleDelete(key: String): SiriusResult = requestHandler.handleDelete(key)
+
+    override def onBootstrapComplete(): Unit = {
+        // allow the GC to collect the map
+        sequences = null
+        requestHandler.onBootstrapComplete()
+    }
+
+    override def handlePut(sequence: Long, key: String, body: Array[Byte]): SiriusResult = {
+        latest(key, sequence) {
+            requestHandler.handlePut(sequence, key, body)
+        }
+    }
+
+    override def handleDelete(sequence: Long, key: String): SiriusResult = {
+        latest(key, sequence) {
+            requestHandler.handleDelete(sequence, key)
+        }
+    }
+
+    private def latest(key: String, sequence: Long)(f: => SiriusResult) = {
+        val sequences = this.sequences
+        if (sequences != null) {
+            var result = SiriusResult.none()
+            sequences.compute(key, (_, existing) => {
+                if (existing < sequence) {
+                    result = f
+                    sequence
+                } else existing
+            })
+            result
+        } else {
+            f
+        }
+    }
+}

--- a/src/main/scala/com/comcast/xfinity/sirius/api/SiriusResult.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/SiriusResult.scala
@@ -16,6 +16,8 @@
 package com.comcast.xfinity.sirius.api
 
 object SiriusResult {
+  private val NONE: SiriusResult = SiriusResult(Right(None))
+  private val OK: SiriusResult = some("ok")
   
   /**
    * Factory method for creating a SiriusResult with a value
@@ -26,13 +28,20 @@ object SiriusResult {
    * @return SiriusResult
    */
   def some(value: Object): SiriusResult = SiriusResult(Right(Some(value)))
+
+  /**
+   * Factory method for creating a SiriusResult with the String value "ok"
+   *
+   * @return SiriusResult
+   */
+  def ok(): SiriusResult = OK
   
   /**
    * Factory method for creating a SiriusResult with no value
    * 
    * @return SiriusResult 
    */
-  def none(): SiriusResult = SiriusResult(Right(None))
+  def none(): SiriusResult = NONE
   
   /**
    * Factory method for creating a SiriusResult with an error.

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
@@ -20,6 +20,7 @@ import better.files.File
 import com.comcast.xfinity.sirius.api.SiriusConfiguration
 import com.comcast.xfinity.sirius.api.impl.OrderedEvent
 import com.comcast.xfinity.sirius.uberstore.data.UberDataFileHandleFactory
+import com.comcast.xfinity.sirius.uberstore.segmented.ParallelHelpers.ParSeqConverter
 import com.comcast.xfinity.sirius.writeaheadlog.SiriusLog
 
 import scala.annotation.tailrec
@@ -136,7 +137,7 @@ class SegmentedUberStore private[segmented] (base: JFile,
   def getNextSeq = nextSeq
 
   override def parallelForeach[T](fun: OrderedEvent => T): Unit = {
-    ParallelHelpers.parallelize(readOnlyDirs :+ liveDir)
+    (readOnlyDirs :+ liveDir).parallelize
             .foreach(_.foldLeftRange(0, Long.MaxValue)(())((_, e) => fun(e)))
   }
 

--- a/src/test/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandlerTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandlerTest.scala
@@ -11,7 +11,7 @@ class ParallelBootstrapRequestHandlerTest extends NiceTest {
             val response = mock[SiriusResult]
             when(requestHandler.handlePut("key1", Array.empty)).thenReturn(response)
 
-            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val underTest = ParallelBootstrapRequestHandler(requestHandler)
             val result = underTest.handlePut("key1", Array.empty)
 
             assert(result === response)
@@ -23,7 +23,7 @@ class ParallelBootstrapRequestHandlerTest extends NiceTest {
             val response = mock[SiriusResult]
             when(requestHandler.handlePut(1L, "key1", Array.empty)).thenReturn(response)
 
-            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val underTest = ParallelBootstrapRequestHandler(requestHandler)
             val result = underTest.handlePut(1L, "key1", Array.empty)
 
             assert(result === response)
@@ -35,7 +35,7 @@ class ParallelBootstrapRequestHandlerTest extends NiceTest {
             val response = mock[SiriusResult]
             when(requestHandler.handleDelete("key1")).thenReturn(response)
 
-            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val underTest = ParallelBootstrapRequestHandler(requestHandler)
             val result = underTest.handleDelete("key1")
 
             assert(result === response)
@@ -47,7 +47,7 @@ class ParallelBootstrapRequestHandlerTest extends NiceTest {
             val response = mock[SiriusResult]
             when(requestHandler.handleDelete(1L, "key1")).thenReturn(response)
 
-            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val underTest = ParallelBootstrapRequestHandler(requestHandler)
             val result = underTest.handleDelete(1L, "key1")
 
             assert(result === response)
@@ -59,7 +59,7 @@ class ParallelBootstrapRequestHandlerTest extends NiceTest {
             val response = mock[SiriusResult]
             when(requestHandler.handleGet("key1")).thenReturn(response)
 
-            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val underTest = ParallelBootstrapRequestHandler(requestHandler)
             val result = underTest.handleGet("key1")
 
             assert(result === response)
@@ -69,7 +69,7 @@ class ParallelBootstrapRequestHandlerTest extends NiceTest {
         it("onBootstrapStarting") {
             val requestHandler = mock[RequestHandler]
 
-            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val underTest = ParallelBootstrapRequestHandler(requestHandler)
             underTest.onBootstrapStarting()
 
             verify(requestHandler).onBootstrapStarting()
@@ -78,7 +78,7 @@ class ParallelBootstrapRequestHandlerTest extends NiceTest {
         it("onBootstrapComplete") {
             val requestHandler = mock[RequestHandler]
 
-            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val underTest = ParallelBootstrapRequestHandler(requestHandler)
             underTest.onBootstrapComplete()
 
             verify(requestHandler).onBootstrapComplete()
@@ -89,7 +89,7 @@ class ParallelBootstrapRequestHandlerTest extends NiceTest {
     describe("during bootstrap") {
         it ("drops out-of-order events for the same key") {
             val requestHandler = mock[RequestHandler]
-            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val underTest = ParallelBootstrapRequestHandler(requestHandler)
 
             underTest.onBootstrapStarting()
             verify(requestHandler).onBootstrapStarting()
@@ -104,7 +104,7 @@ class ParallelBootstrapRequestHandlerTest extends NiceTest {
         }
         it ("allows out-of-order events for different keys") {
             val requestHandler = mock[RequestHandler]
-            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val underTest = ParallelBootstrapRequestHandler(requestHandler)
 
             underTest.onBootstrapStarting()
             verify(requestHandler).onBootstrapStarting()

--- a/src/test/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandlerTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandlerTest.scala
@@ -1,0 +1,122 @@
+package com.comcast.xfinity.sirius.api
+
+import com.comcast.xfinity.sirius.NiceTest
+import org.mockito.Mockito.{verify, verifyNoMoreInteractions, when}
+
+class ParallelBootstrapRequestHandlerTest extends NiceTest {
+
+    describe("delegates") {
+        it("handlePut") {
+            val requestHandler = mock[RequestHandler]
+            val response = mock[SiriusResult]
+            when(requestHandler.handlePut("key1", Array.empty)).thenReturn(response)
+
+            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val result = underTest.handlePut("key1", Array.empty)
+
+            assert(result === response)
+            verify(requestHandler).handlePut("key1", Array.empty)
+            verifyNoMoreInteractions(requestHandler)
+        }
+        it("handlePut with sequence") {
+            val requestHandler = mock[RequestHandler]
+            val response = mock[SiriusResult]
+            when(requestHandler.handlePut(1L, "key1", Array.empty)).thenReturn(response)
+
+            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val result = underTest.handlePut(1L, "key1", Array.empty)
+
+            assert(result === response)
+            verify(requestHandler).handlePut(1L, "key1", Array.empty)
+            verifyNoMoreInteractions(requestHandler)
+        }
+        it("handleDelete") {
+            val requestHandler = mock[RequestHandler]
+            val response = mock[SiriusResult]
+            when(requestHandler.handleDelete("key1")).thenReturn(response)
+
+            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val result = underTest.handleDelete("key1")
+
+            assert(result === response)
+            verify(requestHandler).handleDelete("key1")
+            verifyNoMoreInteractions(requestHandler)
+        }
+        it("handleDelete with sequence") {
+            val requestHandler = mock[RequestHandler]
+            val response = mock[SiriusResult]
+            when(requestHandler.handleDelete(1L, "key1")).thenReturn(response)
+
+            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val result = underTest.handleDelete(1L, "key1")
+
+            assert(result === response)
+            verify(requestHandler).handleDelete(1L, "key1")
+            verifyNoMoreInteractions(requestHandler)
+        }
+        it("handleGet") {
+            val requestHandler = mock[RequestHandler]
+            val response = mock[SiriusResult]
+            when(requestHandler.handleGet("key1")).thenReturn(response)
+
+            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            val result = underTest.handleGet("key1")
+
+            assert(result === response)
+            verify(requestHandler).handleGet("key1")
+            verifyNoMoreInteractions(requestHandler)
+        }
+        it("onBootstrapStarting") {
+            val requestHandler = mock[RequestHandler]
+
+            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            underTest.onBootstrapStarting()
+
+            verify(requestHandler).onBootstrapStarting()
+            verifyNoMoreInteractions(requestHandler)
+        }
+        it("onBootstrapComplete") {
+            val requestHandler = mock[RequestHandler]
+
+            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+            underTest.onBootstrapComplete()
+
+            verify(requestHandler).onBootstrapComplete()
+            verifyNoMoreInteractions(requestHandler)
+        }
+    }
+
+    describe("during bootstrap") {
+        it ("drops out-of-order events for the same key") {
+            val requestHandler = mock[RequestHandler]
+            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+
+            underTest.onBootstrapStarting()
+            verify(requestHandler).onBootstrapStarting()
+
+            underTest.handlePut(1L, "key1", Array.empty)
+            underTest.handlePut(4L, "key1", Array.empty)
+            underTest.handlePut(3L, "key1", Array.empty)
+
+            verify(requestHandler).handlePut(1L, "key1", Array.empty)
+            verify(requestHandler).handlePut(4L, "key1", Array.empty)
+            verifyNoMoreInteractions(requestHandler)
+        }
+        it ("allows out-of-order events for different keys") {
+            val requestHandler = mock[RequestHandler]
+            val underTest = new ParallelBootstrapRequestHandler(requestHandler)
+
+            underTest.onBootstrapStarting()
+            verify(requestHandler).onBootstrapStarting()
+
+            underTest.handlePut(1L, "key1", Array.empty)
+            underTest.handlePut(4L, "key1", Array.empty)
+            underTest.handlePut(3L, "key2", Array.empty)
+
+            verify(requestHandler).handlePut(1L, "key1", Array.empty)
+            verify(requestHandler).handlePut(4L, "key1", Array.empty)
+            verify(requestHandler).handlePut(3L, "key2", Array.empty)
+            verifyNoMoreInteractions(requestHandler)
+        }
+    }
+}


### PR DESCRIPTION
Adds `RequestHandler` helper implementations to handle parallel bootstrap by "compacting" events live.

Also adds singleton instances of common SiriusResult values to reduce allocations.