### PR TITLE
Adds parallel flag to onBootstrapStarted notification

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ import java.lang.{Runtime => JRuntime}
 name := "sirius"
 
 versionScheme := Some("semver-spec")
-version := "2.5.0"
+version := "2.5.1"
 ThisBuild / tlBaseVersion := "2.5"
 
 scalaVersion := "2.13.6"

--- a/src/main/scala/com/comcast/xfinity/sirius/api/AbstractParallelBootstrapRequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/AbstractParallelBootstrapRequestHandler.scala
@@ -21,19 +21,18 @@ abstract class AbstractParallelBootstrapRequestHandler[K, M] extends RequestHand
     }
 
     final override def handleGet(key: String): SiriusResult =
-        if (enabled()) handleGetImpl(createKey(key))
-        else SiriusResult.none()
+        handleGetImpl(createKey(key))
 
     final override def handlePut(key: String, body: Array[Byte]): SiriusResult =
-        if (enabled()) handlePutImpl(createKey(key), deserialize(body))
+        if (writesEnabled()) handlePutImpl(createKey(key), deserialize(body))
         else SiriusResult.none()
 
     final override def handleDelete(key: String): SiriusResult =
-        if (enabled()) handleDeleteImpl(createKey(key))
+        if (writesEnabled()) handleDeleteImpl(createKey(key))
         else SiriusResult.none()
 
     final override def handlePut(sequence: Long, key: String, body: Array[Byte]): SiriusResult =
-        if (enabled())
+        if (writesEnabled())
             sequences match {
                 case Some(map) =>
                     val k = createKey(key)
@@ -78,7 +77,7 @@ abstract class AbstractParallelBootstrapRequestHandler[K, M] extends RequestHand
             case None => handleDeleteImpl(sequence, createKey(key))
         }
 
-    protected def enabled(): Boolean
+    protected def writesEnabled(): Boolean = true
     protected def createKey(key: String): K
     @throws[Exception] protected def deserialize(body: Array[Byte]): M
 

--- a/src/main/scala/com/comcast/xfinity/sirius/api/AbstractParallelBootstrapRequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/AbstractParallelBootstrapRequestHandler.scala
@@ -42,15 +42,7 @@ abstract class AbstractParallelBootstrapRequestHandler[K, M] extends RequestHand
                     else {
                         var result: SiriusResult = SiriusResult.none()
                         // deserialize the body before calling compute to reduce lock contention
-                        val message = try {
-                            deserialize(body)
-                        }
-                        catch {
-                            case ex: RuntimeException =>
-                                return SiriusResult.error(ex)
-                            case ex: Exception =>
-                                return SiriusResult.error(new RuntimeException(ex))
-                        }
+                        val message = deserialize(body)
 
                         // Scala 2.11 has limited support for Java functional interfaces
                         val updateFunction = new BiFunction[K, Long, Long]() {

--- a/src/main/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandler.scala
@@ -6,7 +6,7 @@ object ParallelBootstrapRequestHandler {
 }
 
 class ParallelBootstrapRequestHandler(val requestHandler: RequestHandler) extends AbstractParallelBootstrapRequestHandler[String, Array[Byte]] {
-    override protected def enabled(): Boolean = true
+    override protected def writesEnabled(): Boolean = true
     override protected def createKey(key: String): String = key
     override protected def deserialize(body: Array[Byte]): Array[Byte] = body
     override def handleGetImpl(key: String): SiriusResult = requestHandler.handleGet(key)

--- a/src/main/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/ParallelBootstrapRequestHandler.scala
@@ -15,6 +15,6 @@ class ParallelBootstrapRequestHandler(val requestHandler: RequestHandler) extend
     override def handlePutImpl(sequence: Long, key: String, body: Array[Byte]): SiriusResult = requestHandler.handlePut(sequence, key, body)
     override def handleDeleteImpl(sequence: Long, key: String): SiriusResult = requestHandler.handleDelete(sequence, key)
 
-    override def onBootstrapStartingImpl(): Unit = requestHandler.onBootstrapStarting()
+    override def onBootstrapStartingImpl(parallel: Boolean): Unit = requestHandler.onBootstrapStarting(parallel)
     override def onBootstrapCompletedImpl(): Unit = requestHandler.onBootstrapComplete()
 }

--- a/src/main/scala/com/comcast/xfinity/sirius/api/RequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/RequestHandler.scala
@@ -94,8 +94,10 @@ trait RequestHandler {
 
   /**
    * Indicates that the Sirius bootstrap from the Uberstore is starting
+   *
+   * @param parallel whether bootstrap is in parallel mode
    */
-  def onBootstrapStarting(): Unit = { }
+  def onBootstrapStarting(parallel: Boolean): Unit = { }
 
   /**
    * Indicates that the Sirius bootstrap from Uberstore has completed

--- a/src/main/scala/com/comcast/xfinity/sirius/api/RequestHandler.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/RequestHandler.scala
@@ -95,9 +95,15 @@ trait RequestHandler {
   /**
    * Indicates that the Sirius bootstrap from the Uberstore is starting
    *
+   */
+  def onBootstrapStarting(): Unit = { }
+
+  /**
+   * Indicates that the Sirius bootstrap from the Uberstore is starting
+   *
    * @param parallel whether bootstrap is in parallel mode
    */
-  def onBootstrapStarting(parallel: Boolean): Unit = { }
+  def onBootstrapStarting(parallel: Boolean): Unit = onBootstrapStarting()
 
   /**
    * Indicates that the Sirius bootstrap from Uberstore has completed

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/state/StateSup.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/state/StateSup.scala
@@ -122,7 +122,7 @@ class StateSup(requestHandler: RequestHandler,
         val parallel = config.getProp(SiriusConfiguration.LOG_PARALLEL_ENABLED, default = false)
         val start = System.currentTimeMillis
         logger.info("Beginning SiriusLog replay at {}", start)
-        requestHandler.onBootstrapStarting()
+        requestHandler.onBootstrapStarting(parallel)
         if (parallel) {
           siriusLog.parallelForeach(bootstrapEvent)
         } else {


### PR DESCRIPTION
Adds a parallel flag to the onBootstrapStarted notification to permit request handler to prepare book keeping for parallel bootstrap.  This is to allow the request handler to avoid the additional heap and compute resources necessary to perform live compaction when parallel bootstrapping is not enabled.