### PR TITLE
Add GetLogSubrangeWithLimit message to query log ranges by window and maximum events

### DIFF
--- a/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/SiriusConfiguration.scala
@@ -299,6 +299,16 @@ object SiriusConfiguration {
   final val CATCHUP_MAX_WINDOW_SIZE = "sirius.catchup.max-window-size"
 
   /**
+   * Use log limit for congestion avoidance for catchup.  Default is false.
+   */
+  final val CATCHUP_USE_LIMIT = "sirius.catchup.use-limit"
+
+  /**
+   * Maximum catchup limit size, in number of events. Default is 1000.
+   */
+  final val CATCHUP_MAX_LIMIT_SIZE = "sirius.catchup.max-limit-size"
+
+  /**
    * Starting ssthresh, which is the point where catchup transitions from Slow Start to
    * Congestion Avoidance. Default is 500.
    */

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisor.scala
@@ -15,14 +15,16 @@
  */
 package com.comcast.xfinity.sirius.api.impl.bridge
 
-import akka.actor.{ActorRef, Props, Actor}
+import akka.actor.{Actor, ActorRef, Props}
 import akka.pattern.ask
+
 import scala.concurrent.duration._
 import com.comcast.xfinity.sirius.api.impl.membership.MembershipHelper
 import com.comcast.xfinity.sirius.api.SiriusConfiguration
 import com.comcast.xfinity.sirius.api.impl.bridge.CatchupSupervisor.CatchupSupervisorInfoMBean
-import com.comcast.xfinity.sirius.api.impl.state.SiriusPersistenceActor.{GetLogSubrange, LogSubrange, CompleteSubrange}
+import com.comcast.xfinity.sirius.api.impl.state.SiriusPersistenceActor.{CompleteSubrange, GetLogSubrangeToLimit, LogSubrange}
 import com.comcast.xfinity.sirius.admin.MonitoringHooks
+
 import scala.util.Success
 
 case class InitiateCatchup(fromSeq: Long)
@@ -120,7 +122,7 @@ private[bridge] class CatchupSupervisor(membershipHelper: MembershipHelper,
   }
 
   def requestSubrange(fromSeq: Long, window: Int, source: ActorRef): Unit = {
-    source.ask(GetLogSubrange(fromSeq, fromSeq + window))(timeout()).onComplete {
+    source.ask(GetLogSubrangeToLimit(fromSeq, window))(timeout()).onComplete {
       case Success(logSubrange: LogSubrange) => self ! CatchupRequestSucceeded(logSubrange)
       case _ => self ! CatchupRequestFailed
     }

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisor.scala
@@ -38,7 +38,7 @@ object CatchupSupervisor {
 
   trait CatchupSupervisorInfoMBean {
     def getSSThresh: Int
-    def getWindow: Int
+    def getLimit: Int
   }
 
   /**
@@ -52,9 +52,14 @@ object CatchupSupervisor {
     val timeoutCoeff = config.getDouble(SiriusConfiguration.CATCHUP_TIMEOUT_INCREASE_PER_EVENT, .01)
     val timeoutConst = config.getDouble(SiriusConfiguration.CATCHUP_TIMEOUT_BASE, 1.0)
     val maxWindowSize = config.getInt(SiriusConfiguration.CATCHUP_MAX_WINDOW_SIZE, 1000)
+    val maxLimitSize = if (config.getProp(SiriusConfiguration.CATCHUP_USE_LIMIT, false)) {
+      config.getProp[Int](SiriusConfiguration.CATCHUP_MAX_LIMIT_SIZE)
+    } else {
+      None
+    }
     // must ensure ssthresh <= maxWindowSize
-    val startingSSThresh = Math.min(maxWindowSize, config.getInt(SiriusConfiguration.CATCHUP_DEFAULT_SSTHRESH, 500))
-    Props(new CatchupSupervisor(membershipHelper, timeoutCoeff, timeoutConst, maxWindowSize, startingSSThresh, config))
+    val startingSSThresh = Math.min(maxLimitSize.getOrElse(maxWindowSize), config.getInt(SiriusConfiguration.CATCHUP_DEFAULT_SSTHRESH, 500))
+    Props(new CatchupSupervisor(membershipHelper, timeoutCoeff, timeoutConst, maxWindowSize, maxLimitSize, startingSSThresh, config))
   }
 }
 
@@ -78,28 +83,29 @@ private[bridge] class CatchupSupervisor(membershipHelper: MembershipHelper,
                                         timeoutCoeff: Double,
                                         timeoutConst: Double,
                                         maxWindowSize: Int,
+                                        maxLimitSize: Option[Int],
                                         var ssthresh: Int,
                                         config: SiriusConfiguration) extends Actor with MonitoringHooks {
 
-  var window = 1
-  def timeout() = (timeoutConst + (window * timeoutCoeff)).seconds
+  var limit = 1
+  def timeout() = (timeoutConst + (limit * timeoutCoeff)).seconds
 
   implicit val executionContext = context.dispatcher
 
   def receive = {
     case InitiateCatchup(fromSeq) =>
       membershipHelper.getRandomMember.map(remote => {
-        requestSubrange(fromSeq, window, remote)
+        requestSubrange(fromSeq, limit, remote)
         context.become(catchup(remote))
       })
   }
 
   def catchup(source: ActorRef): Receive = {
     case CatchupRequestSucceeded(logSubrange: CompleteSubrange) =>
-      if (window >= ssthresh) { // we're in Congestion Avoidance phase
-        window = Math.min(window + 2, maxWindowSize)
+      if (limit >= ssthresh) { // we're in Congestion Avoidance phase
+        limit = Math.min(limit + 2, maxLimitSize.getOrElse(maxWindowSize))
       } else { // we're in Slow Start phase
-        window = Math.min(window * 2, ssthresh)
+        limit = Math.min(limit * 2, ssthresh)
       }
       context.parent ! logSubrange
 
@@ -107,22 +113,26 @@ private[bridge] class CatchupSupervisor(membershipHelper: MembershipHelper,
       context.parent ! logSubrange
 
     case CatchupRequestFailed =>
-      if (window != 1) {
+      if (limit != 1) {
         // adjust ssthresh, revert to Slow Start phase
-        ssthresh = Math.max(window / 2, 1)
-        window = 1
+        ssthresh = Math.max(limit / 2, 1)
+        limit = 1
       }
       context.unbecome()
 
     case ContinueCatchup(fromSeq: Long) =>
-      requestSubrange(fromSeq, window, source)
+      requestSubrange(fromSeq, limit, source)
 
     case StopCatchup =>
       context.unbecome()
   }
 
-  def requestSubrange(fromSeq: Long, window: Int, source: ActorRef): Unit = {
-    source.ask(GetLogSubrange(fromSeq, fromSeq + window))(timeout()).onComplete {
+  def requestSubrange(fromSeq: Long, limit: Int, source: ActorRef): Unit = {
+    val message = maxLimitSize match {
+      case Some(_) => GetLogSubrangeWithLimit(fromSeq, fromSeq + maxWindowSize, limit)
+      case None => GetLogSubrange(fromSeq, fromSeq + limit)
+    }
+    source.ask(message)(timeout()).onComplete {
       case Success(logSubrange: LogSubrange) => self ! CatchupRequestSucceeded(logSubrange)
       case _ => self ! CatchupRequestFailed
     }
@@ -137,6 +147,6 @@ private[bridge] class CatchupSupervisor(membershipHelper: MembershipHelper,
 
   class CatchupSupervisorInfo extends CatchupSupervisorInfoMBean {
     def getSSThresh = ssthresh
-    def getWindow = window
+    def getLimit = limit
   }
 }

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisor.scala
@@ -22,7 +22,7 @@ import scala.concurrent.duration._
 import com.comcast.xfinity.sirius.api.impl.membership.MembershipHelper
 import com.comcast.xfinity.sirius.api.SiriusConfiguration
 import com.comcast.xfinity.sirius.api.impl.bridge.CatchupSupervisor.CatchupSupervisorInfoMBean
-import com.comcast.xfinity.sirius.api.impl.state.SiriusPersistenceActor.{CompleteSubrange, GetLogSubrangeToLimit, LogSubrange}
+import com.comcast.xfinity.sirius.api.impl.state.SiriusPersistenceActor.{CompleteSubrange, GetLogSubrangeWithLimit, LogSubrange}
 import com.comcast.xfinity.sirius.admin.MonitoringHooks
 
 import scala.util.Success
@@ -122,7 +122,7 @@ private[bridge] class CatchupSupervisor(membershipHelper: MembershipHelper,
   }
 
   def requestSubrange(fromSeq: Long, window: Int, source: ActorRef): Unit = {
-    source.ask(GetLogSubrangeToLimit(fromSeq, window))(timeout()).onComplete {
+    source.ask(GetLogSubrangeWithLimit(fromSeq, Long.MaxValue, window))(timeout()).onComplete {
       case Success(logSubrange: LogSubrange) => self ! CatchupRequestSucceeded(logSubrange)
       case _ => self ! CatchupRequestFailed
     }

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisor.scala
@@ -22,7 +22,7 @@ import scala.concurrent.duration._
 import com.comcast.xfinity.sirius.api.impl.membership.MembershipHelper
 import com.comcast.xfinity.sirius.api.SiriusConfiguration
 import com.comcast.xfinity.sirius.api.impl.bridge.CatchupSupervisor.CatchupSupervisorInfoMBean
-import com.comcast.xfinity.sirius.api.impl.state.SiriusPersistenceActor.{CompleteSubrange, GetLogSubrangeWithLimit, LogSubrange}
+import com.comcast.xfinity.sirius.api.impl.state.SiriusPersistenceActor.{CompleteSubrange, GetLogSubrange, GetLogSubrangeWithLimit, LogSubrange}
 import com.comcast.xfinity.sirius.admin.MonitoringHooks
 
 import scala.util.Success
@@ -122,7 +122,7 @@ private[bridge] class CatchupSupervisor(membershipHelper: MembershipHelper,
   }
 
   def requestSubrange(fromSeq: Long, window: Int, source: ActorRef): Unit = {
-    source.ask(GetLogSubrangeWithLimit(fromSeq, Long.MaxValue, window))(timeout()).onComplete {
+    source.ask(GetLogSubrange(fromSeq, fromSeq + window))(timeout()).onComplete {
       case Success(logSubrange: LogSubrange) => self ! CatchupRequestSucceeded(logSubrange)
       case _ => self ! CatchupRequestFailed
     }

--- a/src/main/scala/com/comcast/xfinity/sirius/api/impl/state/SiriusPersistenceActor.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/api/impl/state/SiriusPersistenceActor.scala
@@ -43,7 +43,7 @@ object SiriusPersistenceActor {
    * @param end last sequence number of the range, inclusive
    */
   case class GetLogSubrange(begin: Long, end: Long) extends LogQuery
-  case class GetLogRangeLimit(begin: Long, events: Long) extends LogQuery
+  case class GetLogSubrangeToLimit(begin: Long, events: Long) extends LogQuery
 
   trait LogSubrange
   trait PopulatedSubrange extends LogSubrange {
@@ -132,7 +132,7 @@ class SiriusPersistenceActor(stateActor: ActorRef,
 
       lastWriteTime = thisWriteTime
 
-    case GetLogRangeLimit(start, limit) =>
+    case GetLogSubrangeToLimit(start, limit) =>
       val buffer = siriusLog.foldLeftWhile(start)(ListBuffer.empty[OrderedEvent])(buffer => buffer.length < limit)(
         (acc, event) => acc += event
       )

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberPair.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberPair.scala
@@ -107,6 +107,11 @@ class UberPair(dataFile: UberDataFile, index: SeqIndex) {
     )
   }
 
+  def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
+    val (startOffset, _) = index.getOffsetRange(startSeq, Long.MaxValue)
+    dataFile.foldLeftWhile(startOffset)(acc0)(pred)(foldFun)
+  }
+
   /**
    * Close underlying file handles or connections.  This UberStoreFilePair should not be used after
    * close is called.

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberPair.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberPair.scala
@@ -107,9 +107,9 @@ class UberPair(dataFile: UberDataFile, index: SeqIndex) {
     )
   }
 
-  def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
-    val (startOffset, _) = index.getOffsetRange(startSeq, Long.MaxValue)
-    dataFile.foldLeftWhile(startOffset)(acc0)(pred)(foldFun)
+  def foldLeftRangeWhile[T](startSeq: Long, endSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
+    val (startOffset, endOffset) = index.getOffsetRange(startSeq, endSeq)
+    dataFile.foldLeftRangeWhile(startOffset, endOffset)(acc0)(pred)(foldFun)
   }
 
   /**

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberStore.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberStore.scala
@@ -85,8 +85,8 @@ class UberStore private[uberstore] (baseDir: String, uberpair: UberPair) extends
   /**
    * @inheritdoc
    */
-  def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
-    uberpair.foldLeftWhile(startSeq)(acc0)(pred)(foldFun)
+  def foldLeftRangeWhile[T](startSeq: Long, endSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
+    uberpair.foldLeftRangeWhile(startSeq, endSeq)(acc0)(pred)(foldFun)
   }
 
   /**

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberStore.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/UberStore.scala
@@ -83,6 +83,13 @@ class UberStore private[uberstore] (baseDir: String, uberpair: UberPair) extends
     uberpair.foldLeftRange(startSeq, endSeq)(acc0)(foldFun)
 
   /**
+   * @inheritdoc
+   */
+  def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
+    uberpair.foldLeftWhile(startSeq)(acc0)(pred)(foldFun)
+  }
+
+  /**
    * Close underlying file handles or connections.  This UberStore should not be used after
    * close is called.
    */

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/UberDataFile.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/data/UberDataFile.scala
@@ -101,7 +101,16 @@ private[uberstore] class UberDataFile(dataFileName: String,
   def foldLeftRange[T](baseOff: Long, endOff: Long)(acc0: T)(foldFun: (T, Long, OrderedEvent) => T): T = {
     val readHandle = fileHandleFactory.createReadHandle(dataFileName, baseOff)
     try {
-      foldLeftUntil(readHandle, endOff, acc0, foldFun)
+      foldLeftUntilOffset(readHandle, endOff, acc0, foldFun)
+    } finally {
+      readHandle.close()
+    }
+  }
+
+  def foldLeftWhile[T](baseOff:Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
+    val readHandle = fileHandleFactory.createReadHandle(dataFileName, baseOff)
+    try {
+      foldLeftWhile(readHandle, acc0, pred, foldFun)
     } finally {
       readHandle.close()
     }
@@ -109,7 +118,7 @@ private[uberstore] class UberDataFile(dataFileName: String,
 
   // private low low low level fold left
   @tailrec
-  private def foldLeftUntil[T](readHandle: UberDataFileReadHandle, maxOffset: Long, acc: T, foldFun: (T, Long, OrderedEvent) => T): T = {
+  private def foldLeftUntilOffset[T](readHandle: UberDataFileReadHandle, maxOffset: Long, acc: T, foldFun: (T, Long, OrderedEvent) => T): T = {
     val offset = readHandle.offset()
     if (offset > maxOffset) {
       acc
@@ -118,7 +127,21 @@ private[uberstore] class UberDataFile(dataFileName: String,
         case None => acc
         case Some(bytes) =>
           val accNew = foldFun(acc, offset, codec.deserialize(bytes))
-          foldLeftUntil(readHandle, maxOffset, accNew, foldFun)
+          foldLeftUntilOffset(readHandle, maxOffset, accNew, foldFun)
+      }
+    }
+  }
+
+  @tailrec
+  private def foldLeftWhile[T](readHandle: UberDataFileReadHandle, acc: T, pred: T => Boolean, foldFun: (T, OrderedEvent) => T): T = {
+    if (!pred(acc)) {
+      acc
+    } else {
+      fileOps.readNext(readHandle) match {
+        case None => acc
+        case Some(bytes) =>
+          val accNew = foldFun(acc, codec.deserialize(bytes))
+          foldLeftWhile(readHandle, accNew, pred, foldFun)
       }
     }
   }

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/Segment.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/Segment.scala
@@ -172,12 +172,12 @@ class Segment private[uberstore](val location: File,
     )
   }
 
-  def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T =
-    index.getOffsetRange(startSeq, Long.MaxValue) match {
+  def foldLeftRangeWhile[T](startSeq: Long, endSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T =
+    index.getOffsetRange(startSeq, endSeq) match {
       case (_, endOffset) if endOffset == -1 => // indicates an empty range
         acc0
-      case (startOffset, _) =>
-        dataFile.foldLeftWhile(startOffset)(acc0)(pred)(
+      case (startOffset, endOffset) =>
+        dataFile.foldLeftRangeWhile(startOffset, endOffset)(acc0)(pred)(
           (acc, evt) => foldFun(acc, evt)
         )
     }

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
@@ -154,11 +154,11 @@ class SegmentedUberStore private[segmented] (base: JFile,
   /**
    * @inheritdoc
    */
-  def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
+  def foldLeftRangeWhile[T](startSeq: Long, endSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
     val res0 = readOnlyDirs.foldLeft(acc0)(
-      (acc, dir) => dir.foldLeftWhile(startSeq)(acc)(pred)(foldFun)
+      (acc, dir) => dir.foldLeftRangeWhile(startSeq, endSeq)(acc)(pred)(foldFun)
     )
-    liveDir.foldLeftWhile(startSeq)(res0)(pred)(foldFun)
+    liveDir.foldLeftRangeWhile(startSeq, endSeq)(res0)(pred)(foldFun)
   }
 
   /**

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStore.scala
@@ -151,6 +151,15 @@ class SegmentedUberStore private[segmented] (base: JFile,
     liveDir.foldLeftRange(startSeq, endSeq)(res0)(foldFun)
   }
 
+  /**
+   * @inheritdoc
+   */
+  def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
+    val res0 = readOnlyDirs.foldLeft(acc0)(
+      (acc, dir) => dir.foldLeftWhile(startSeq)(acc)(pred)(foldFun)
+    )
+    liveDir.foldLeftWhile(startSeq)(res0)(pred)(foldFun)
+  }
 
   /**
    * Close underlying file handles or connections.  This SegmentedUberStore should not be used after

--- a/src/main/scala/com/comcast/xfinity/sirius/uberstore/seqindex/SeqIndex.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/uberstore/seqindex/SeqIndex.scala
@@ -26,6 +26,13 @@ trait SeqIndex {
   def getOffsetFor(seq: Long): Option[Long]
 
   /**
+   * Get the minimum sequence number stored, if such exists
+   *
+   * @return Some(sequence) or None if none such exists
+   */
+  def getMinSeq: Option[Long]
+
+  /**
    * Get the maximum sequence number stored, if such exists
    *
    * @return Some(sequence) or None if none such exists

--- a/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/CachedSiriusLog.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/CachedSiriusLog.scala
@@ -108,6 +108,9 @@ class CachedSiriusLog(log: SiriusLog, maxCacheSize: Int) extends SiriusLog {
       .values.asScala.foldLeft(acc0)(foldFun)
   }
 
+  override def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T =
+    log.foldLeftWhile(startSeq)(acc0)(pred)(foldFun)
+
   def getNextSeq = log.getNextSeq
 
   def compact(): Unit = {

--- a/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/SiriusLog.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/SiriusLog.scala
@@ -60,6 +60,15 @@ trait SiriusLog {
   def foldLeftRange[T](startSeq: Long, endSeq: Long)(acc0: T)(foldFun: (T, OrderedEvent) => T): T
 
   /**
+   * Fold left across log entries while a condition is met
+   * @param startSeq sequence number to start with, inclusive
+   * @param acc0 initial accumulator value
+   * @param pred condition to continue accumulating log entries
+   * @param foldFun function to apply to the log entry, the result being the new accumulator
+   */
+  def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T
+
+  /**
    * retrieves the next sequence number to be written
    */
   def getNextSeq: Long

--- a/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/SiriusLog.scala
+++ b/src/main/scala/com/comcast/xfinity/sirius/writeaheadlog/SiriusLog.scala
@@ -66,7 +66,7 @@ trait SiriusLog {
    * @param pred condition to continue accumulating log entries
    * @param foldFun function to apply to the log entry, the result being the new accumulator
    */
-  def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T
+  def foldLeftRangeWhile[T](startSeq: Long, endSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T
 
   /**
    * retrieves the next sequence number to be written

--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisorTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisorTest.scala
@@ -53,7 +53,7 @@ class CatchupSupervisorTest extends NiceTest {
 
       underTest ! InitiateCatchup(1L)
 
-      remote.expectMsgClass(classOf[GetLogSubrangeWithLimit])
+      remote.expectMsgClass(classOf[GetLogSubrange])
     }
     describe("for successful requests with a complete subrange") {
       it("should forward the message on to the parent") {
@@ -176,7 +176,7 @@ class CatchupSupervisorTest extends NiceTest {
 
       underTest ! ContinueCatchup(1L)
 
-      remote.expectMsg(GetLogSubrangeWithLimit(1L, Long.MaxValue, 1L))
+      remote.expectMsg(GetLogSubrange(1L, 2L))
     }
     it("should ignore InitiateCatchup requests if it's currently in catchup mode") {
       val remote = TestProbe()
@@ -197,7 +197,7 @@ class CatchupSupervisorTest extends NiceTest {
       underTest ! StopCatchup
       underTest ! InitiateCatchup(1L)
 
-      remote.expectMsg(GetLogSubrangeWithLimit(1L, Long.MaxValue, 1L))
+      remote.expectMsg(GetLogSubrange(1L, 2L))
     }
   }
 }

--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisorTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisorTest.scala
@@ -53,7 +53,7 @@ class CatchupSupervisorTest extends NiceTest {
 
       underTest ! InitiateCatchup(1L)
 
-      remote.expectMsgClass(classOf[GetLogSubrange])
+      remote.expectMsgClass(classOf[GetLogSubrangeToLimit])
     }
     describe("for successful requests with a complete subrange") {
       it("should forward the message on to the parent") {
@@ -176,7 +176,7 @@ class CatchupSupervisorTest extends NiceTest {
 
       underTest ! ContinueCatchup(1L)
 
-      remote.expectMsg(GetLogSubrange(1L, 2L))
+      remote.expectMsg(GetLogSubrangeToLimit(1L, 1L))
     }
     it("should ignore InitiateCatchup requests if it's currently in catchup mode") {
       val remote = TestProbe()
@@ -197,7 +197,7 @@ class CatchupSupervisorTest extends NiceTest {
       underTest ! StopCatchup
       underTest ! InitiateCatchup(1L)
 
-      remote.expectMsg(GetLogSubrange(1L, 2L))
+      remote.expectMsg(GetLogSubrangeToLimit(1L, 1L))
     }
   }
 }

--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisorTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/bridge/CatchupSupervisorTest.scala
@@ -53,7 +53,7 @@ class CatchupSupervisorTest extends NiceTest {
 
       underTest ! InitiateCatchup(1L)
 
-      remote.expectMsgClass(classOf[GetLogSubrangeToLimit])
+      remote.expectMsgClass(classOf[GetLogSubrangeWithLimit])
     }
     describe("for successful requests with a complete subrange") {
       it("should forward the message on to the parent") {
@@ -176,7 +176,7 @@ class CatchupSupervisorTest extends NiceTest {
 
       underTest ! ContinueCatchup(1L)
 
-      remote.expectMsg(GetLogSubrangeToLimit(1L, 1L))
+      remote.expectMsg(GetLogSubrangeWithLimit(1L, Long.MaxValue, 1L))
     }
     it("should ignore InitiateCatchup requests if it's currently in catchup mode") {
       val remote = TestProbe()
@@ -197,7 +197,7 @@ class CatchupSupervisorTest extends NiceTest {
       underTest ! StopCatchup
       underTest ! InitiateCatchup(1L)
 
-      remote.expectMsg(GetLogSubrangeToLimit(1L, 1L))
+      remote.expectMsg(GetLogSubrangeWithLimit(1L, Long.MaxValue, 1L))
     }
   }
 }

--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/state/SiriusPersistenceActorTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/state/SiriusPersistenceActorTest.scala
@@ -72,7 +72,7 @@ class SiriusPersistenceActorTest extends NiceTest {
   }
 
   def verifyFoldLeftWhile(siriusLog: SiriusLog, start: Long): Unit = {
-    verify(siriusLog).foldLeftWhile(meq(start))(meq(ListBuffer[OrderedEvent]()))(any[ListBuffer[OrderedEvent] => Boolean])(any[(ListBuffer[OrderedEvent], OrderedEvent) => ListBuffer[OrderedEvent]])
+    verify(siriusLog).foldLeftWhile(meq(start))(meq(ListBuffer[OrderedEvent]()))(any[ListBuffer[OrderedEvent] => Boolean]())(any[(ListBuffer[OrderedEvent], OrderedEvent) => ListBuffer[OrderedEvent]]())
   }
 
   describe("a SiriusPersistenceActor") {

--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/state/SiriusPersistenceActorTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/state/SiriusPersistenceActorTest.scala
@@ -194,7 +194,7 @@ class SiriusPersistenceActorTest extends NiceTest {
           val mockLog = makeMockLog(ListBuffer(event1, event2), 10L)
           val underTest = makePersistenceActor(siriusLog = mockLog)
 
-          senderProbe.send(underTest, GetLogRangeLimit(1, 2))
+          senderProbe.send(underTest, GetLogSubrangeToLimit(1, 2))
 
           verifyFoldLeftWhile(mockLog, 1)
           senderProbe.expectMsg(CompleteSubrange(1, 2, List(event1, event2)))
@@ -211,7 +211,7 @@ class SiriusPersistenceActorTest extends NiceTest {
           val mockLog = makeMockLog(ListBuffer(event1, event2), 10L)
           val underTest = makePersistenceActor(siriusLog = mockLog)
 
-          senderProbe.send(underTest, GetLogRangeLimit(8, 3))
+          senderProbe.send(underTest, GetLogSubrangeToLimit(8, 3))
 
           verifyFoldLeftWhile(mockLog, 8)
           senderProbe.expectMsg(PartialSubrange(8, 9, List(event1, event2)))
@@ -224,7 +224,7 @@ class SiriusPersistenceActorTest extends NiceTest {
           val mockLog = makeMockLog(ListBuffer(), 5L)
           val underTest = makePersistenceActor(siriusLog = mockLog)
 
-          senderProbe.send(underTest, GetLogRangeLimit(8, 11))
+          senderProbe.send(underTest, GetLogSubrangeToLimit(8, 11))
 
           verifyFoldLeftWhile(mockLog, 8)
           senderProbe.expectMsg(EmptySubrange)

--- a/src/test/scala/com/comcast/xfinity/sirius/api/impl/state/SiriusPersistenceActorTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/api/impl/state/SiriusPersistenceActorTest.scala
@@ -194,7 +194,7 @@ class SiriusPersistenceActorTest extends NiceTest {
           val mockLog = makeMockLog(ListBuffer(event1, event2), 10L)
           val underTest = makePersistenceActor(siriusLog = mockLog)
 
-          senderProbe.send(underTest, GetLogSubrangeWithLimit(1, 2, 2))
+          senderProbe.send(underTest, GetLogSubrangeWithLimit(1, Some(2), 2))
 
           verifyFoldLeftRanged(mockLog, 1, 2)
           senderProbe.expectMsg(CompleteSubrange(1, 2, List(event1, event2)))
@@ -205,16 +205,16 @@ class SiriusPersistenceActorTest extends NiceTest {
           val senderProbe = TestProbe()
 
           val event1 = mock[OrderedEvent]
-          doReturn(8L).when(event1).sequence
+          doReturn(1L).when(event1).sequence
           val event2 = mock[OrderedEvent]
-          doReturn(9L).when(event2).sequence
+          doReturn(2L).when(event2).sequence
           val mockLog = makeMockLog(ListBuffer(event1, event2), 10L)
           val underTest = makePersistenceActor(siriusLog = mockLog)
 
-          senderProbe.send(underTest, GetLogSubrangeWithLimit(8, Long.MaxValue, 3))
+          senderProbe.send(underTest, GetLogSubrangeWithLimit(1, None, 3))
 
-          verifyFoldLeftWhile(mockLog, 8, 9)
-          senderProbe.expectMsg(PartialSubrange(8, 9, List(event1, event2)))
+          verifyFoldLeftWhile(mockLog, 1, 9)
+          senderProbe.expectMsg(CompleteSubrange(1, 9, List(event1, event2)))
         }
       }
       describe("when we can partially reply due to limit") {
@@ -222,16 +222,16 @@ class SiriusPersistenceActorTest extends NiceTest {
           val senderProbe = TestProbe()
 
           val event1 = mock[OrderedEvent]
-          doReturn(8L).when(event1).sequence
+          doReturn(1L).when(event1).sequence
           val event2 = mock[OrderedEvent]
-          doReturn(9L).when(event2).sequence
+          doReturn(2L).when(event2).sequence
           val mockLog = makeMockLog(ListBuffer(event1, event2), 11L)
           val underTest = makePersistenceActor(siriusLog = mockLog)
 
-          senderProbe.send(underTest, GetLogSubrangeWithLimit(8, 10, 2))
+          senderProbe.send(underTest, GetLogSubrangeWithLimit(1, Some(10), 2))
 
-          verifyFoldLeftWhile(mockLog, 8, 10)
-          senderProbe.expectMsg(PartialSubrange(8, 9, List(event1, event2)))
+          verifyFoldLeftWhile(mockLog, 1, 10)
+          senderProbe.expectMsg(PartialSubrange(1, 2, List(event1, event2)))
         }
       }
       describe("when we can't send anything useful at all") {
@@ -241,7 +241,7 @@ class SiriusPersistenceActorTest extends NiceTest {
           val mockLog = makeMockLog(ListBuffer(), 5L)
           val underTest = makePersistenceActor(siriusLog = mockLog)
 
-          senderProbe.send(underTest, GetLogSubrangeWithLimit(8, Long.MaxValue, 11))
+          senderProbe.send(underTest, GetLogSubrangeWithLimit(8, None, 11))
 
           senderProbe.expectMsg(EmptySubrange)
         }

--- a/src/test/scala/com/comcast/xfinity/sirius/itest/DoNothingSiriusLog.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/itest/DoNothingSiriusLog.scala
@@ -32,7 +32,9 @@ class DoNothingSiriusLog extends SiriusLog {
     acc0
   }
 
-  override def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = acc0
+  override def foldLeftRangeWhile[T](startSeq: Long, endSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
+    acc0
+  }
 
   override def getNextSeq = 1L
 

--- a/src/test/scala/com/comcast/xfinity/sirius/itest/DoNothingSiriusLog.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/itest/DoNothingSiriusLog.scala
@@ -32,6 +32,8 @@ class DoNothingSiriusLog extends SiriusLog {
     acc0
   }
 
+  override def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = acc0
+
   override def getNextSeq = 1L
 
   override def compact(): Unit = {}

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/UberToolTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/UberToolTest.scala
@@ -36,29 +36,20 @@ object UberToolTest {
     def foldLeftRange[T](start: Long, end: Long)(acc0: T)(foldFun: (T, OrderedEvent) => T): T =
       events.filter(e => start <= e.sequence && e.sequence <= end).foldLeft(acc0)(foldFun)
 
-    def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
-      var acc: T = acc0
-      for (evt <- events) {
-        if (!pred(acc)) {
-          return acc
-        }
-        acc = foldFun(acc, evt)
-      }
-      acc
+    def foldLeftRangeWhile[T](start: Long, end: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
+      val filtered = events.filter(e => start <= e.sequence && e.sequence <= end)
+      foldLeftRangeWhile(filtered, acc0, pred, foldFun)
     }
 
     @tailrec
-    private def foldLeftWhile[T](events: List[OrderedEvent], startSeq: Long, acc: T, pred: T => Boolean, foldFun: (T, OrderedEvent) => T): T = {
+    private def foldLeftRangeWhile[T](events: List[OrderedEvent], acc: T, pred: T => Boolean, foldFun: (T, OrderedEvent) => T): T =
       events match {
         case Nil => acc
-        case evt :: rest if evt.sequence < startSeq =>
-          foldLeftWhile(rest, startSeq, acc, pred, foldFun)
         case _ if !pred(acc) => acc
         case evt :: rest =>
           val accNew = foldFun(acc, evt)
-          foldLeftWhile(rest, startSeq, accNew, pred, foldFun)
+          foldLeftRangeWhile(rest, accNew, pred, foldFun)
       }
-    }
 
     def getNextSeq: Long =
       throw new IllegalStateException("not implemented")

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/UberToolTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/UberToolTest.scala
@@ -19,10 +19,12 @@ package com.comcast.xfinity.sirius.uberstore
 import com.comcast.xfinity.sirius.NiceTest
 import com.comcast.xfinity.sirius.writeaheadlog.SiriusLog
 import com.comcast.xfinity.sirius.api.impl.{Delete, OrderedEvent, Put}
-import java.io.{File => JFile}
 
+import java.io.{File => JFile}
 import better.files.File
 import com.comcast.xfinity.sirius.uberstore.segmented.SegmentedUberStore
+
+import scala.annotation.tailrec
 
 object UberToolTest {
   class DummySiriusLog(var events: List[OrderedEvent]) extends SiriusLog {
@@ -33,6 +35,30 @@ object UberToolTest {
 
     def foldLeftRange[T](start: Long, end: Long)(acc0: T)(foldFun: (T, OrderedEvent) => T): T =
       events.filter(e => start <= e.sequence && e.sequence <= end).foldLeft(acc0)(foldFun)
+
+    def foldLeftWhile[T](startSeq: Long)(acc0: T)(pred: T => Boolean)(foldFun: (T, OrderedEvent) => T): T = {
+      var acc: T = acc0
+      for (evt <- events) {
+        if (!pred(acc)) {
+          return acc
+        }
+        acc = foldFun(acc, evt)
+      }
+      acc
+    }
+
+    @tailrec
+    private def foldLeftWhile[T](events: List[OrderedEvent], startSeq: Long, acc: T, pred: T => Boolean, foldFun: (T, OrderedEvent) => T): T = {
+      events match {
+        case Nil => acc
+        case evt :: rest if evt.sequence < startSeq =>
+          foldLeftWhile(rest, startSeq, acc, pred, foldFun)
+        case _ if !pred(acc) => acc
+        case evt :: rest =>
+          val accNew = foldFun(acc, evt)
+          foldLeftWhile(rest, startSeq, accNew, pred, foldFun)
+      }
+    }
 
     def getNextSeq: Long =
       throw new IllegalStateException("not implemented")

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
@@ -197,7 +197,7 @@ class SegmentedUberStoreTest extends NiceTest {
     }
   }
 
-  describe("foldLeftWhile") {
+  describe("foldLeftRangeWhile") {
     it("should limit events based on predicate on accumulator") {
       createPopulatedSegment(dir, "1", Range.inclusive(1, 3).toList)
       createPopulatedSegment(dir, "5", Range.inclusive(4, 6).toList)
@@ -206,7 +206,7 @@ class SegmentedUberStoreTest extends NiceTest {
       uberstore.writeEntry(OrderedEvent(10L, 1L, Delete("10")))
       uberstore.writeEntry(OrderedEvent(11L, 1L, Delete("11")))
 
-      val result = uberstore.foldLeftWhile(startSeq = 1)(List[SiriusRequest]())(list => list.size < 5)(
+      val result = uberstore.foldLeftRangeWhile(startSeq = 1, endSeq = Long.MaxValue)(List[SiriusRequest]())(list => list.size < 5)(
         (acc, event) => event.request +: acc
       ).reverse
 
@@ -221,7 +221,7 @@ class SegmentedUberStoreTest extends NiceTest {
       uberstore.writeEntry(OrderedEvent(10L, 1L, Delete("10")))
       uberstore.writeEntry(OrderedEvent(11L, 1L, Delete("11")))
 
-      val result = uberstore.foldLeftWhile(startSeq = 9)(List[SiriusRequest]())(list => list.size < 2)(
+      val result = uberstore.foldLeftRangeWhile(startSeq = 9, endSeq = Long.MaxValue)(List[SiriusRequest]())(list => list.size < 2)(
         (acc, event) => event.request +: acc
       ).reverse
 

--- a/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
+++ b/src/test/scala/com/comcast/xfinity/sirius/uberstore/segmented/SegmentedUberStoreTest.scala
@@ -182,7 +182,7 @@ class SegmentedUberStoreTest extends NiceTest {
   }
 
   describe("foldLeftRange") {
-    it("should reflect livedir's nextSeq") {
+    it("should include livedir's events") {
       createSegment(dir, "1")
       createSegment(dir, "5")
       createSegment(dir, "10")
@@ -194,6 +194,38 @@ class SegmentedUberStoreTest extends NiceTest {
           (acc, event) => event.request +: acc
         ).reverse
       )
+    }
+  }
+
+  describe("foldLeftWhile") {
+    it("should limit events based on predicate on accumulator") {
+      createPopulatedSegment(dir, "1", Range.inclusive(1, 3).toList)
+      createPopulatedSegment(dir, "5", Range.inclusive(4, 6).toList)
+      createPopulatedSegment(dir, "10", Range.inclusive(7, 9).toList)
+      uberstore = SegmentedUberStore(dir.getAbsolutePath, new SiriusConfiguration)
+      uberstore.writeEntry(OrderedEvent(10L, 1L, Delete("10")))
+      uberstore.writeEntry(OrderedEvent(11L, 1L, Delete("11")))
+
+      val result = uberstore.foldLeftWhile(startSeq = 1)(List[SiriusRequest]())(list => list.size < 5)(
+        (acc, event) => event.request +: acc
+      ).reverse
+
+      assert(result === List(Delete("1"), Delete("2"), Delete("3"), Delete("4"), Delete("5")))
+    }
+
+    it("should include livedir's events") {
+      createPopulatedSegment(dir, "1", Range.inclusive(1, 3).toList)
+      createPopulatedSegment(dir, "5", Range.inclusive(4, 6).toList)
+      createPopulatedSegment(dir, "10", Range.inclusive(7, 9).toList)
+      uberstore = SegmentedUberStore(dir.getAbsolutePath, new SiriusConfiguration)
+      uberstore.writeEntry(OrderedEvent(10L, 1L, Delete("10")))
+      uberstore.writeEntry(OrderedEvent(11L, 1L, Delete("11")))
+
+      val result = uberstore.foldLeftWhile(startSeq = 9)(List[SiriusRequest]())(list => list.size < 2)(
+        (acc, event) => event.request +: acc
+      ).reverse
+
+      assert(result === List(Delete("9"), Delete("10")))
     }
   }
 


### PR DESCRIPTION
Adds a new LogQuery message for querying the Sirius log for a subrange based on a range of sequences and a maximum limit of events to include in the response.  This would allow catchup to specify a larger window of events that is capped by a maximum number of events so that the returned list would be more full in the case of gaps caused by compaction.